### PR TITLE
Support for autometad regression testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@ target
 ucli.key
 .*.swp
 test-*
+
+# These come from building SoftFloat/TestFloat
+/berkeley-*float-3
+/testfloat_gen

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 default: all
 
-berkeley-softfloat-3/extract.stamp: patches/SoftFloat-3/*
+berkeley-softfloat-3/extract.stamp: patches/berkeley-softfloat-3/*
 	rm -rf berkeley-softfloat-3
 	git clone git://github.com/ucb-bar/berkeley-softfloat-3.git
 	patch -p0 < patches/berkeley-softfloat-3/0001-specialize_riscv.patch
@@ -90,6 +90,22 @@ all: $(tests)
 
 verilog: $(addsuffix -v, $(tests))
 	@ if grep abort test-v-*.*.log; then \
+		echo "some tests FAILED!!!"; \
+		exit 1; \
+	fi
+
+# These targets are used by the buildbot -- they skip tests that are
+# expected to fail.
+.PHONY: autocheck-c
+autocheck-c: $(tests) expected_failures
+	@ if find test-c-*.*.log | grep -v -f expected_failures | xargs grep -l abort; then \
+		echo "some tests FAILED!!!"; \
+		exit 1; \
+	fi
+
+.PHONY: autocheck-v
+autocheck-v: $(addsuffix -v, $(tests)) expected_failures
+	@ if find test-v-*.*.log | grep -v -f expected_failures | xargs grep -l abort; then \
 		echo "some tests FAILED!!!"; \
 		exit 1; \
 	fi

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,25 @@
 default: all
 
-ifeq (, $(shell which testfloat_gen))
-$(error "No testfloat_gen in $(PATH), install testfloat_gen")
-endif
+berkeley-softfloat-3/extract.stamp: patches/SoftFloat-3/*
+	rm -rf berkeley-softfloat-3
+	git clone git://github.com/ucb-bar/berkeley-softfloat-3.git
+	patch -p0 < patches/berkeley-softfloat-3/0001-specialize_riscv.patch
+	touch berkeley-softfloat-3/extract.stamp
+
+berkeley-testfloat-3/extract.stamp:
+	rm -rf berkeley-testfloat-3
+	git clone git://github.com/ucb-bar/berkeley-testfloat-3.git
+	touch berkeley-testfloat-3/extract.stamp
+
+berkeley-softfloat-3/build/Linux-x86_64-GCC/softfloat.a: berkeley-softfloat-3/extract.stamp
+	$(MAKE) -C berkeley-softfloat-3/build/Linux-x86_64-GCC
+
+berkeley-testfloat-3/build/Linux-x86_64-GCC/testfloat_gen: berkeley-testfloat-3/extract.stamp \
+                                                           berkeley-softfloat-3/build/Linux-x86_64-GCC/softfloat.a
+	$(MAKE) -C berkeley-testfloat-3/build/Linux-x86_64-GCC
+
+testfloat_gen: berkeley-testfloat-3/build/Linux-x86_64-GCC/testfloat_gen
+	cp berkeley-testfloat-3/build/Linux-x86_64-GCC/testfloat_gen .
 
 tests = \
 	f32_mulAdd \
@@ -22,17 +39,17 @@ test-$(1)/dut: test-$(1)/Test_$(1).cpp csrc/*.h csrc/*.cpp
 	g++ -c -o test-$(1)/Test_$(1).o $$<
 	g++ -o $$@ test-$(1)/Test_$(1).o test-$(1)/emulator.o
 
-test-c-$(1).near_even.log: test-$(1)/dut
-	{ time testfloat_gen -rnear_even $(1) | $$< 0 ; } > $$@ 2>&1
+test-c-$(1).near_even.log: test-$(1)/dut testfloat_gen
+	{ time ./testfloat_gen -rnear_even $(1) | $$< 0 ; } > $$@ 2>&1
 
-test-c-$(1).minMag.log: test-$(1)/dut
-	{ time testfloat_gen -rminMag $(1) | $$< 1 ; } > $$@ 2>&1
+test-c-$(1).minMag.log: test-$(1)/dut testfloat_gen
+	{ time ./testfloat_gen -rminMag $(1) | $$< 1 ; } > $$@ 2>&1
 
-test-c-$(1).min.log: test-$(1)/dut
-	{ time testfloat_gen -rmin $(1) | $$< 2 ; } > $$@ 2>&1
+test-c-$(1).min.log: test-$(1)/dut testfloat_gen
+	{ time ./testfloat_gen -rmin $(1) | $$< 2 ; } > $$@ 2>&1
 
-test-c-$(1).max.log: test-$(1)/dut
-	{ time testfloat_gen -rmax $(1) | $$< 3 ; } > $$@ 2>&1
+test-c-$(1).max.log: test-$(1)/dut testfloat_gen
+	{ time ./testfloat_gen -rmax $(1) | $$< 3 ; } > $$@ 2>&1
 
 $(1): $$(addsuffix .log, $$(addprefix test-c-$(1)., near_even minMag min max))
 
@@ -45,17 +62,17 @@ test-$(1)/simv: test-$(1)/Test_$(1).v
 test-$(1)/simv-debug: test-$(1)/Test_$(1).v
 	cd test-$(1) && vcs -full64 -timescale=1ns/10ps +define+EXPERIMENT=\"emulator-$(1).vh\" +incdir+../vsrc +define+DEBUG -debug_pp $$(notdir $$<) ../vsrc/emulator.v -o $$(notdir $$@)
 
-test-v-$(1).near_even.log: test-$(1)/simv
-	{ time testfloat_gen -rnear_even $(1) | $$< +rm=0 ; } > $$@ 2>&1
+test-v-$(1).near_even.log: test-$(1)/simv testfloat_gen
+	{ time ./testfloat_gen -rnear_even $(1) | $$< +rm=0 ; } > $$@ 2>&1
 
-test-v-$(1).minMag.log: test-$(1)/simv
-	{ time testfloat_gen -rminMag $(1) | $$< +rm=1 ; } > $$@ 2>&1
+test-v-$(1).minMag.log: test-$(1)/simv testfloat_gen
+	{ time ./testfloat_gen -rminMag $(1) | $$< +rm=1 ; } > $$@ 2>&1
 
-test-v-$(1).min.log: test-$(1)/simv
-	{ time testfloat_gen -rmin $(1) | $$< +rm=2 ; } > $$@ 2>&1
+test-v-$(1).min.log: test-$(1)/simv testfloat_gen
+	{ time ./testfloat_gen -rmin $(1) | $$< +rm=2 ; } > $$@ 2>&1
 
-test-v-$(1).max.log: test-$(1)/simv
-	{ time testfloat_gen -rmax $(1) | $$< +rm=3 ; } > $$@ 2>&1
+test-v-$(1).max.log: test-$(1)/simv testfloat_gen
+	{ time ./testfloat_gen -rmax $(1) | $$< +rm=3 ; } > $$@ 2>&1
 
 $(1)-v: $$(addsuffix .log, $$(addprefix test-v-$(1)., near_even minMag min max))
 
@@ -78,6 +95,6 @@ verilog: $(addsuffix -v, $(tests))
 	fi
 
 clean:
-	rm -rf test* ucli.key
+	rm -rf test* ucli.key *.zip berkeley-*float-3  testfloat_gen
 
 .PHONY: $(tests) clean

--- a/csrc/emulator.cpp
+++ b/csrc/emulator.cpp
@@ -22,7 +22,7 @@ int main (int argc, char* argv[])
   }
 
   // main operation
-  while (true) {
+  while (cnt < (1UL << 20)) {
     if (!process_inputs()) break;
     if (!process_outputs()) break;
 
@@ -41,7 +41,7 @@ int main (int argc, char* argv[])
           expected_recoded->to_str().c_str(), actual_recoded->to_str().c_str(),
           expected_exception->to_str().c_str(), expected_exception->to_str().c_str());
         if (error == 20) {
-          printf("reached %ld errors. aborting.\n", error);
+          printf("reached %ld errors in %ld tests. aborting.\n", error, cnt);
           break;
         }
       }
@@ -50,6 +50,9 @@ int main (int argc, char* argv[])
 
     module->clock_hi(LIT<1>(0));
   }
+
+  if (error > 0)
+    printf("reached %ld errors in %ld tests. aborting.\n", error, cnt);
   
   return 0;
 }

--- a/expected_failures
+++ b/expected_failures
@@ -1,0 +1,8 @@
+test-c-f32_mulAdd.max.log
+test-c-f32_mulAdd.min.log
+test-c-f64_mulAdd.max.log
+test-c-f64_mulAdd.min.log
+test-v-f32_mulAdd.max.log
+test-v-f32_mulAdd.min.log
+test-v-f64_mulAdd.max.log
+test-v-f64_mulAdd.min.log

--- a/patches/berkeley-softfloat-3/0001-specialize_riscv.patch
+++ b/patches/berkeley-softfloat-3/0001-specialize_riscv.patch
@@ -1,0 +1,12 @@
+diff -ur berkeley-softfloat-3.orig/build/Linux-x86_64-GCC/Makefile berkeley-softfloat-3/build/Linux-x86_64-GCC/Makefile
+--- berkeley-softfloat-3.orig/build/Linux-x86_64-GCC/Makefile	2015-03-26 19:30:48.521070658 -0700
++++ berkeley-softfloat-3/build/Linux-x86_64-GCC/Makefile	2015-03-26 19:31:53.891071268 -0700
+@@ -32,7 +32,7 @@
+ #=============================================================================
+ 
+ SOURCE_DIR = ../../source
+-SPECIALIZE_TYPE = 8086-SSE
++SPECIALIZE_TYPE = RISCV
+ 
+ SOFTFLOAT_OPTS = -DINLINE_LEVEL=5 -DSOFTFLOAT_FAST_DIV64TO32
+ 


### PR DESCRIPTION
I want to start running these tests as part of the buildbot.  This patch set adds some Makefile changes that allow this to happen.  It ends up masking out a few tests that (according to Yunsup) are expected to fail.