### PR TITLE
suggest names for all submodules

### DIFF
--- a/src/main/scala/DivSqrtRecF64.scala
+++ b/src/main/scala/DivSqrtRecF64.scala
@@ -57,6 +57,7 @@ class DivSqrtRecF64 extends Module
     }
 
     val ds = Module(new DivSqrtRecF64_mulAddZ31)
+    ds.suggestName("dsInst")
 
     io.inReady_div := ds.io.inReady_div
     io.inReady_sqrt := ds.io.inReady_sqrt
@@ -71,6 +72,7 @@ class DivSqrtRecF64 extends Module
     io.exceptionFlags := ds.io.exceptionFlags
 
     val mul = Module(new Mul54)
+    mul.suggestName("mulInst")
 
     mul.io.val_s0 := ds.io.usingMulAdd(0)
     mul.io.latch_a_s0 := ds.io.latchMulAddA_0

--- a/src/main/scala/MulAddRecFN.scala
+++ b/src/main/scala/MulAddRecFN.scala
@@ -596,8 +596,10 @@ class MulAddRecFN(expWidth: Int, sigWidth: Int) extends Module
 
     val mulAddRecFN_preMul =
         Module(new MulAddRecFN_preMul(expWidth, sigWidth))
+    mulAddRecFN_preMul.suggestName("mulAddRecFN_preMulInst")
     val mulAddRecFN_postMul =
         Module(new MulAddRecFN_postMul(expWidth, sigWidth))
+    mulAddRecFN_postMul.suggestName("mulAddRecFN_postMulInst")
 
     mulAddRecFN_preMul.io.op := io.op
     mulAddRecFN_preMul.io.a  := io.a

--- a/src/main/scala/RecFNToRecFN.scala
+++ b/src/main/scala/RecFNToRecFN.scala
@@ -100,6 +100,7 @@ class
 
         val roundRawFNToRecFN =
             Module(new RoundRawFNToRecFN(outExpWidth, outSigWidth))
+        roundRawFNToRecFN.suggestName("roundRawFNToRecFNInst")
         roundRawFNToRecFN.io.invalidExc := invalidExc
         roundRawFNToRecFN.io.infiniteExc := Bool(false)
         roundRawFNToRecFN.io.in := outRawFloat


### PR DESCRIPTION
This allows chisel to not uniquify hardfloat modules
that are created with identical parameters.

@aswaterman This is a pretty trivial change but I want to be able to use a MIM flow downstream and without this change chisel always emits different instance names for these modules despite identical arguments. This could eventually be fixed by chisel3/#303 but for now I'm moving forward with this work around.