### PR TITLE
Fix some chisel3 compatibility problems

### DIFF
--- a/src/main/scala/DivSqrtRecF64_mulAddZ31.scala
+++ b/src/main/scala/DivSqrtRecF64_mulAddZ31.scala
@@ -335,7 +335,7 @@ class DivSqrtRecF64ToRaw_mulAddZ31(options: Int) extends Module
         sign_PA     := sign_S
     }
     when (entering_PA_normalCase) {
-        sExp_PA := Mux(io.sqrtOp, rawB_S.sExp, sSatExpQuot_S_div)
+        sExp_PA := Mux(io.sqrtOp, rawB_S.sExp, sSatExpQuot_S_div).asUInt
         fractB_PA := rawB_S.sig(51, 0)
         roundingMode_PA := io.roundingMode
     }
@@ -705,9 +705,10 @@ class DivSqrtRecF64ToRaw_mulAddZ31(options: Int) extends Module
     io.rawOut.isZero := isZero_PC
     io.rawOut.sign := sign_PC
     io.rawOut.sExp :=
-        Mux(! sqrtOp_PC &&   E_E_div, sExp_PC,                     UInt(0)) |
-        Mux(! sqrtOp_PC && ! E_E_div, sExpP1_PC,                   UInt(0)) |
-        Mux(  sqrtOp_PC,              (sExp_PC>>1) + UInt("h400"), UInt(0))
+        ( Mux(! sqrtOp_PC &&   E_E_div, sExp_PC,                     UInt(0)) |
+          Mux(! sqrtOp_PC && ! E_E_div, sExpP1_PC,                   UInt(0)) |
+          Mux(  sqrtOp_PC,              (sExp_PC>>1) + UInt("h400"), UInt(0))
+        ).asSInt
     io.rawOut.sig := Cat(Mux(trueLtX_E1, sigT_E, sigTP1_E), ! trueEqX_E1)
 
 }

--- a/src/main/scala/MulAddRecFN.scala
+++ b/src/main/scala/MulAddRecFN.scala
@@ -202,7 +202,7 @@ class MulAddRecFNToRaw_postMul(expWidth: Int, sigWidth: Int) extends Module
     //------------------------------------------------------------------------
     //------------------------------------------------------------------------
     val CDom_sign = opSignC
-    val CDom_sExp = io.fromPreMul.sExpSum - io.fromPreMul.doSubMags
+    val CDom_sExp = io.fromPreMul.sExpSum - io.fromPreMul.doSubMags.zext
     val CDom_absSigSum =
         Mux(io.fromPreMul.doSubMags,
             ~sigSum(sigSumWidth - 1, sigWidth + 1),
@@ -240,7 +240,7 @@ class MulAddRecFNToRaw_postMul(expWidth: Int, sigWidth: Int) extends Module
     val notCDom_reduced2AbsSigSum = orReduceBy2(notCDom_absSigSum)
     val notCDom_normDistReduced2 = countLeadingZeros(notCDom_reduced2AbsSigSum)
     val notCDom_nearNormDist = notCDom_normDistReduced2<<1
-    val notCDom_sExp = io.fromPreMul.sExpSum - notCDom_nearNormDist
+    val notCDom_sExp = io.fromPreMul.sExpSum - notCDom_nearNormDist.zext
     val notCDom_mainSig =
         (notCDom_absSigSum<<notCDom_nearNormDist)(
             sigWidth * 2 + 3, sigWidth - 1)

--- a/src/main/scala/RoundAnyRawFNToRecFN.scala
+++ b/src/main/scala/RoundAnyRawFNToRecFN.scala
@@ -115,12 +115,12 @@ class
     val doShiftSigDown1 =
         if (sigMSBitAlwaysZero) Bool(false) else adjustedSig(outSigWidth + 2)
 
-    val common_expOut   = UInt(width = outExpWidth + 1)
-    val common_fractOut = UInt(width = outSigWidth - 1)
-    val common_overflow       = Bool()
-    val common_totalUnderflow = Bool()
-    val common_underflow      = Bool()
-    val common_inexact        = Bool()
+    val common_expOut   = Wire(UInt(width = outExpWidth + 1))
+    val common_fractOut = Wire(UInt(width = outSigWidth - 1))
+    val common_overflow       = Wire(Bool())
+    val common_totalUnderflow = Wire(Bool())
+    val common_underflow      = Wire(Bool())
+    val common_inexact        = Wire(Bool())
 
     if (
         neverOverflows && neverUnderflows

--- a/src/main/scala/primitives.scala
+++ b/src/main/scala/primitives.scala
@@ -94,13 +94,13 @@ object orReduceBy2
     def apply(in: UInt): UInt =
     {
         val reducedWidth = (in.getWidth + 1)>>1
-        val reducedVec = Vec(Seq.fill(reducedWidth)(Bool()))
+        val reducedVec = Wire(Vec(reducedWidth, Bool()))
         for (ix <- 0 until reducedWidth - 1) {
             reducedVec(ix) := in(ix * 2 + 1, ix * 2).orR
         }
         reducedVec(reducedWidth - 1) :=
             in(in.getWidth - 1, (reducedWidth - 1) * 2).orR
-        reducedVec.toBits
+        reducedVec.asUInt
     }
 }
 
@@ -111,13 +111,13 @@ object orReduceBy4
     def apply(in: UInt): UInt =
     {
         val reducedWidth = (in.getWidth + 3)>>2
-        val reducedVec = Vec(Seq.fill(reducedWidth)(Bool()))
+        val reducedVec = Wire(Vec(reducedWidth, Bool()))
         for (ix <- 0 until reducedWidth - 1) {
             reducedVec(ix) := in(ix * 4 + 3, ix * 4).orR
         }
         reducedVec(reducedWidth - 1) :=
             in(in.getWidth - 1, (reducedWidth - 1) * 4).orR
-        reducedVec.toBits
+        reducedVec.asUInt
     }
 }
 


### PR DESCRIPTION
These compatibility issues aren't news, but it looks like a few of the old ones have snuck back in recently:

- You can't assign from UInt to SInt, or vice versa, without an explicit cast.  asUInt and asSInt are the type-punning operations.  You can also use zext to convert from a UInt/Bool to an SInt with the same numerical value (i.e., it concatenates a 0 sign bit and converts the type to SInt).
- Local wires need to be declared with Wire, not just the type, e.g., Wire(Vec(n, Bool())) makes a Wire that consists of an n-entry Vec of Bools.