### PR TITLE
Instruction for chisel3 users

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,3 +48,21 @@ To test floating-point units with the C simulator:
 
     $ make
 
+
+Working With Chisel3
+--------------------
+
+For the time being, berkeley hardfloat cannot be downloaded by SBT and users have to compile and publish it locally. For that, first clone this repository:
+    
+    git clone https://github.com/ucb-bar/berkeley-hardfloat.git hardfloat
+    cd hardfloat    
+
+To compile and publish the project locally using chisel3:
+
+    sbt -DchiselVersion="latest.release" publish-local
+
+This will locall publish the hardfloat library. To use hardfloat in your chisel3 project, simply add the following:
+
+    import chisel3._
+    import hardfloat._
+

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ To compile and publish the project locally using chisel3:
 
     sbt -DchiselVersion="latest.release" publish-local
 
-This will locall publish the hardfloat library. To use hardfloat in your chisel3 project, simply add the following:
+This will locally publish the hardfloat library. To use hardfloat in your chisel3 project, simply add the following:
 
     import chisel3._
     import hardfloat._


### PR DESCRIPTION
I added instructions for those who are using chisel3. With the current setup, the sbt publish command results in the following error:

check] ValExec_fNFromRecFN.scala:44: Chisel3 compatibility: io's should be wrapped in IO() in class hardfloat.ValExec_fNFromRecFN$$anon$1

My instructions fixes the issue.