### PR TITLE
Bump scalaVersion to match rocket-chip.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ version := "1.2"
 
 name := "hardfloat"
 
-scalaVersion := "2.11.6"
+scalaVersion := "2.11.12"
 
 // Provide a managed dependency on chisel if -DchiselVersion="" issupplied on the command line.
 libraryDependencies ++= (Seq("chisel").map {


### PR DESCRIPTION
@yunsup @aswaterman @palmer-dabbelt I don't have commit access to this repo, so one of you will need to merge this in.

I'm bumping the Scala version to 2.11.12 to match the current version of rocket-chip. The reason I'm bumping it is because otherwise, sbt will redundantly compile certain dependencies for each individual version of Scala referenced by all sub projects (and sub sub projects).