### PR TITLE
Recurrence relations for Div and Sqrt

### DIFF
--- a/src/main/scala/DivSqrtRecFN_small.scala
+++ b/src/main/scala/DivSqrtRecFN_small.scala
@@ -85,7 +85,7 @@ sig_{s+1} = x_{s+1} * b_{s+1} * pow2(s+2) = x_{s+1} * pow2((s-1)/2) // Shifting 
 
 Hauser's for odd exp:
 ---------------------
-actualInp = 1x.xxxxxxxxxx (width s+1, i.e. s-1 mantissa, 2 rest)
+actualInp = 2*inp (as the remainder for the odd exponent when divided by 2 is observed by the mantissa)
 
 bit_1 = pow2(s-1)
 c_1 = {inp[s-1:s-2]-1, inp[s-3:0], 3'b0} >= {3'b101, (s-1)'b0} <-> {inp, 3'b0} >= {4'b1001, (s-1)'b0}

--- a/src/main/scala/DivSqrtRecFN_small.scala
+++ b/src/main/scala/DivSqrtRecFN_small.scala
@@ -34,91 +34,142 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 =============================================================================*/
 
-/*
 
-Square root:
+
+
+/*
 
 s = sigWidth
 c_i = newBit
 
+Division:
+width of a is (s+2)
 
 Normal
 ------
-(x + b)^2 <= inp
-x^2 + b * (2x + b) <= inp
--------------------------
-x_1^2 <= inp //x_1 <= pow2((s-1)/2)
-b_1 = pow2((s-1)/2)/2
-r_1 = inp - pow2(s-1)
-c_i = bi * (2*x_i + b_i) <= ri
-x_{i+1} = x_i + c_i * b_i
-r_{i+1} = r_i - b_i * (2*x_i + b_i)
-b_{i+1} = b_i/2 = b_1/pow2(i) = pow2((s-1)/2)/pow2(i+1)
------------------------------
-i = 1 to inf
-------------
+
+(qi + ci * 2^(-i))*b <= a
+q0 = 0
+r0 = a
+
+q(i+1) = qi + ci*2^(-i)
+ri = a - qi*b
+r(i+1) = a - q(i+1)*b
+       = a - qi*b - ci*2^(-i)*b
+r(i+1) = ri - ci*2^(-i)*b
+ci = ri >= 2^(-i)*b
+summary_i = ri != 0
+
+i = 0 to s+1
+
+(s+1)th bit plus summary_(i+1) gives enough information for rounding
+If (a < b), then we need to calculate (s+2)th bit and summary_(i+1)
+because we need s bits ignoring the leading zero. (This is skipCycle2
+part of Hauser's code.)
+
+Hauser
+------
+sig_i = qi
+rem_i = 2^(i-2)*ri
+cycle_i = s+3-i
+
+sig_0 = 0
+rem_0 = a/4
+cycle_0 = s+3
+bit_0 = 2^0 (= 2^(s+1), since we represent a, b and q with (s+2) bits)
+
+sig(i+1) = sig(i) + ci*bit_i
+rem(i+1) = 2rem_i - ci*b/2
+ci = 2rem_i >= b/2
+bit_i = 2^-i (=2^(cycle_i-2), since we represent a, b and q with (s+2) bits)
+cycle(i+1) = cycle_i-1
+summary_1 = a <> b
+summary(i+1) = if ci then 2rem_i-b/2 <> 0 else summary_i, i <> 0
+
+Proof:
+2^i*r(i+1) = 2^i*ri - ci*b. Qed
+
+ci = 2^i*ri >= b. Qed
+
+summary(i+1) = if ci then rem(i+1) else summary_i, i <> 0
+Now, note that all of ck's cannot be 0, since that means
+a is 0. So when you traverse through a chain of 0 ck's,
+from the end,
+eventually, you reach a non-zero cj. That is exactly the
+value of ri as the reminder remains the same. When all ck's
+are 0 except c0 (which must be 1) then summary_1 is set
+correctly according
+to r1 = a-b != 0. So summary(i+1) is always set correctly
+according to r(i+1)
 
 
-Hauser's for even exp:
-----------------------
-inp = 1.xxxxxxxxx
 
-sig_i = x_i * b_i * pow2(i+1)
-bit_i = b_i^2 * (pow2(i+1))
-rem_i = r_i * pow2(i)
----------------------
-sig_1 <= pow2(s)
-bit_1 = pow2(s-1)
-rem_1 = 2*inp-pow2(s)
----------------------
-c_i = 2*sig_i + bit_i <= 2*rem_i
-sig_{i+1} = sig_i + c_i * bit_i
-rem_{i+1} = 2*rem_i - c_i*(2*sig_i + bit_i)
-bit_{i+1} = bit_i/2 = bit_1/pow2(i) = b_1^2*pow2(2)/pow2(i) = pow2((s-1)/2)/pow2(i)
--------------------------------------------------------------------------
-i = 1 to (s+1)
---------------
-At {s+1}
-sig_{s+1} = x_{s+1} * b_{s+1} * pow2(s+2) = x_{s+1} * pow2((s-1)/2) // Shifting by (s-1)/2 bits
+Square root:
+width of a is (s+1)
+
+Normal
+------
+(xi + ci*2^(-i))^2 <= a
+xi^2 + ci*2^(-i)*(2xi+ci*2^(-i)) <= a
+
+x0 = 0
+x(i+1) = xi + ci*2^(-i)
+ri = a - xi^2
+r(i+1) = a - x(i+1)^2
+       = a - (xi^2 + ci*2^(-i)*(2xi+ci*2^(-i)))
+       = ri - ci*2^(-i)*(2xi+ci*2^(-i))
+       = ri - ci*2^(-i)*(2xi+2^(-i))  // ci is always 0 or 1
+ci = ri >= 2^(-i)*(2xi + 2^(-i))
+summary_i = ri != 0
 
 
+i = 0 to s+1
 
-Hauser's for odd exp:
----------------------
-actualInp = 2*inp (as the remainder for the odd exponent when divided by 2 is observed by the mantissa)
+For odd expression, do 2 steps initially.
 
-bit_1 = pow2(s-1)
-c_1 = {inp[s-1:s-2]-1, inp[s-3:0], 3'b0} >= {3'b101, (s-1)'b0} <-> {inp, 3'b0} >= {4'b1001, (s-1)'b0}
-sig_2 = {1'b1, c_1, (s-1)'b0}
-rem_2 = {inp[s-1:s-2]-1, inp[s-3:0], 3'b0} - c_1 * {3'b101, (s-1)'b0}
----------------------------------------------------------------------
-i = 2 to s+1
+(s+1)th bit plus summary_(i+1) gives enough information for rounding.
 
-// One extra step is done in the beginning, that's all.
+Hauser
+------
 
-----------------------------------
-sig_2 = sig_1 + c_1 * bit_1
-rem_2 = 2*rem_1 - c_1 * (2*sig_1 + bit_1)
+sig_i = xi
+rem_i = ri*2^(i-1)
+cycle_i = s+2-i
+bit_i = 2^(-i) (= 2^(s-i) = 2^(cycle_i-2) in terms of bit representation)
 
+sig_0 = 0
+rem_0 = a/2
+cycle_0 = s+2
+bit_0 = 1 (= 2^s in terms of bit representation)
 
-c_1 = 2*pow2(s) + pow2(s-1) <= 2*(2*(2*inp) - pow2(s)) <-> 4*pow2(s) + pow2(s-1) <= 4*(2*inp) <-> 9*pow2(s-1) <= 4*(2*inp) <-> {4'b1001, (s-1)'b0} <= 4*(inp * 2)
-sig_1 = pow2(s)
-rem_1 = 2*(2*inp) - pow2(s)
-bit_1 = pow2(s-1)
-
-sig_2 = pow2(s) + c_1 * pow2(s-1) = {1'b1, c_1, (s-1)'b0}
-rem_2 = 2*(2*(2*inp) - pow2(s)) - c_1 * (2*pow2(s) + pow2(s-1))
-      = 8*inp - 4*pow2(s-1) - c_1*(5*pow2(s-1))
-      = {inp[s-1:s-2]-1, inp[s-3:0], 3'b0} - c_1*{3'b101, (s-1)'b0}
-
-// Again, odd just does two steps instead of 1 in the beginning
+sig(i+1) = sig_i + ci * bit_i
+rem(i+1) = 2rem_i - ci*(2sig_i + bit_i)
+ci = 2*sig_i + bit_i <= 2*rem_i
+bit_i = 2^(cycle_i-2) (in terms of bit representation)
+cycle(i+1) = cycle_i-1
+summary_1 = a - (2^s) (in terms of bit representation) 
+summary(i+1) = if ci then rem(i+1) <> 0 else summary_i, i <> 0
 
 
-notZeroRem_Z is enough for rounding because Hauser calculates one extra bit and saves the rest, if non-zero, as 1 (using notZeroRem_Z). It works for every rounding mode.
+Proof:
+ci = 2*sig_i + bit_i <= 2*rem_i
+ci = 2xi + 2^(-i) <= ri*2^i. Qed
 
-Note that all registers are updated normally until cycleNum == 2.
-At cycleNum == 2, rem_Z is not updated, but all other registers are updated normally.
-But, cycleNum == 1 does not read rem_Z to calculate anything, including notZeroRem_Z. So everything is fine.
+sig(i+1) = sig_i + ci * bit_i
+x(i+1) = xi + ci*2^(-i). Qed
+
+rem(i+1) = 2rem_i - ci*(2sig_i + bit_i)
+r(i+1)*2^i = ri*2^i - ci*(2xi + 2^(-i))
+r(i+1) = ri - ci*2^(-i)*(2xi + 2^(-i)). Qed
+
+Same argument as before for summary.
+
+
+------------------------------
+Note that all registers are updated normally until cycle == 2.
+At cycle == 2, rem is not updated, but all other registers are updated normally.
+But, cycle == 1 does not read rem to calculate anything (note that final summary
+is calculated using the values at cycle = 2).
 
 */
 


### PR DESCRIPTION
I have added the algorithm used to compute div and square root as given by the Scala code. This is just documentation for others to understand how floating-point div and square root is implemented here, and it also gives a proof of why it is correct, with respect to a naive implementation of div and square root

