### PR TITLE
modern chisel3 support

### DIFF
--- a/src/main/scala/AddRecFN.scala
+++ b/src/main/scala/AddRecFN.scala
@@ -44,7 +44,7 @@ import consts._
 
 //----------------------------------------------------------------------------
 //----------------------------------------------------------------------------
-class AddRawFN(expWidth: Int, sigWidth: Int) extends chisel3.RawModule
+class AddRawFN(expWidth: Int, sigWidth: Int) extends RawModule
 {
     val io = IO(new Bundle {
         val subOp = Input(Bool())
@@ -130,7 +130,7 @@ class AddRawFN(expWidth: Int, sigWidth: Int) extends chisel3.RawModule
 //----------------------------------------------------------------------------
 //----------------------------------------------------------------------------
 
-class AddRecFN(expWidth: Int, sigWidth: Int) extends chisel3.RawModule
+class AddRecFN(expWidth: Int, sigWidth: Int) extends RawModule
 {
     val io = IO(new Bundle {
         val subOp = Input(Bool())

--- a/src/main/scala/CompareRecFN.scala
+++ b/src/main/scala/CompareRecFN.scala
@@ -37,18 +37,18 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 package hardfloat
 
-import Chisel._
+import chisel3._
 
-class CompareRecFN(expWidth: Int, sigWidth: Int) extends chisel3.RawModule
+class CompareRecFN(expWidth: Int, sigWidth: Int) extends RawModule
 {
     val io = IO(new Bundle {
-        val a = Bits(INPUT, expWidth + sigWidth + 1)
-        val b = Bits(INPUT, expWidth + sigWidth + 1)
-        val signaling = Bool(INPUT)
-        val lt = Bool(OUTPUT)
-        val eq = Bool(OUTPUT)
-        val gt = Bool(OUTPUT)
-        val exceptionFlags = Bits(OUTPUT, 5)
+        val a = Input(Bits((expWidth + sigWidth + 1).W))
+        val b = Input(Bits((expWidth + sigWidth + 1).W))
+        val signaling = Input(Bool())
+        val lt = Output(Bool())
+        val eq = Output(Bool())
+        val gt = Output(Bool())
+        val exceptionFlags = Output(Bits(5.W))
     })
 
     val rawA = rawFloatFromRecFN(expWidth, sigWidth, io.a)
@@ -78,6 +78,6 @@ class CompareRecFN(expWidth: Int, sigWidth: Int) extends chisel3.RawModule
     io.lt := ordered && ordered_lt
     io.eq := ordered && ordered_eq
     io.gt := ordered && ! ordered_lt && ! ordered_eq
-    io.exceptionFlags := Cat(invalid, Bits(0, 4))
+    io.exceptionFlags := invalid ## 0.U(4.W)
 }
 

--- a/src/main/scala/DivSqrtRecF64.scala
+++ b/src/main/scala/DivSqrtRecF64.scala
@@ -37,24 +37,23 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 package hardfloat
 
-import Chisel._
-import consts._
+import chisel3._
 
 class DivSqrtRecF64 extends Module
 {
     val io = IO(new Bundle {
-        val inReady_div  = Bool(OUTPUT)
-        val inReady_sqrt = Bool(OUTPUT)
-        val inValid = Bool(INPUT)
-        val sqrtOp = Bool(INPUT)
-        val a = Bits(INPUT, 65)
-        val b = Bits(INPUT, 65)
-        val roundingMode   = UInt(INPUT, 3)
-        val detectTininess = UInt(INPUT, 1)
-        val outValid_div  = Bool(OUTPUT)
-        val outValid_sqrt = Bool(OUTPUT)
-        val out = Bits(OUTPUT, 65)
-        val exceptionFlags = Bits(OUTPUT, 5)
+        val inReady_div  = Output(Bool())
+        val inReady_sqrt = Output(Bool())
+        val inValid = Input(Bool())
+        val sqrtOp = Input(Bool())
+        val a = Input(Bits(65.W))
+        val b = Input(Bits(65.W))
+        val roundingMode   = Input(Bits(3.W))
+        val detectTininess = Input(UInt(1.W))
+        val outValid_div  = Output(Bool())
+        val outValid_sqrt = Output(Bool())
+        val out = Output(Bits(65.W))
+        val exceptionFlags = Output(Bits(5.W))
     })
 
     val ds = Module(new DivSqrtRecF64_mulAddZ31(0))
@@ -86,22 +85,22 @@ class DivSqrtRecF64 extends Module
 class Mul54 extends Module
 {
     val io = IO(new Bundle {
-        val val_s0 = Bool(INPUT)
-        val latch_a_s0 = Bool(INPUT)
-        val a_s0 = UInt(INPUT, 54)
-        val latch_b_s0 = Bool(INPUT)
-        val b_s0 = UInt(INPUT, 54)
-        val c_s2 = UInt(INPUT, 105)
-        val result_s3 = UInt(OUTPUT, 105)
+        val val_s0 = Input(Bool())
+        val latch_a_s0 = Input(Bool())
+        val a_s0 = Input(UInt(54.W))
+        val latch_b_s0 = Input(Bool())
+        val b_s0 = Input(UInt(54.W))
+        val c_s2 = Input(UInt(105.W))
+        val result_s3 = Output(UInt(105.W))
     })
 
     val val_s1 = Reg(Bool())
     val val_s2 = Reg(Bool())
-    val reg_a_s1 = Reg(UInt(width = 54))
-    val reg_b_s1 = Reg(UInt(width = 54))
-    val reg_a_s2 = Reg(UInt(width = 54))
-    val reg_b_s2 = Reg(UInt(width = 54))
-    val reg_result_s3 = Reg(UInt(width = 105))
+    val reg_a_s1 = Reg(UInt(54.W))
+    val reg_b_s1 = Reg(UInt(54.W))
+    val reg_a_s2 = Reg(UInt(54.W))
+    val reg_b_s2 = Reg(UInt(54.W))
+    val reg_result_s3 = Reg(UInt(105.W))
 
     val_s1 := io.val_s0
     val_s2 := val_s1

--- a/src/main/scala/DivSqrtRecF64_mulAddZ31.scala
+++ b/src/main/scala/DivSqrtRecF64_mulAddZ31.scala
@@ -37,7 +37,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 package hardfloat
 
-import Chisel._
+import chisel3._
+import chisel3.util.{Cat, Fill}
 import consts._
 
 /*----------------------------------------------------------------------------
@@ -47,47 +48,47 @@ import consts._
 | "docs/DivSqrtRecF64_mulAddZ31.txt" for more details.
 *----------------------------------------------------------------------------*/
 
-class DivSqrtRecF64ToRaw_mulAddZ31(options: Int) extends Module
+class DivSqrtRecF64ToRaw_mulAddZ31 extends Module
 {
     val io = IO(new Bundle {
         /*--------------------------------------------------------------------
         *--------------------------------------------------------------------*/
-        val inReady_div    = Bool(OUTPUT)
-        val inReady_sqrt   = Bool(OUTPUT)
-        val inValid        = Bool(INPUT)
-        val sqrtOp         = Bool(INPUT)
-        val a              = Bits(INPUT, 65)
-        val b              = Bits(INPUT, 65)
-        val roundingMode   = UInt(INPUT, 3)
+        val inReady_div    = Output(Bool())
+        val inReady_sqrt   = Output(Bool())
+        val inValid        = Input(Bool())
+        val sqrtOp         = Input(Bool())
+        val a              = Input(Bits(65.W))
+        val b              = Input(Bits(65.W))
+        val roundingMode   = Input(UInt(3.W))
 //*** OPTIONALLY PROPAGATE:
-//        val detectTininess = UInt(INPUT, 1)
+//        val detectTininess = Input(UInt(1.W))
         /*--------------------------------------------------------------------
         *--------------------------------------------------------------------*/
-        val usingMulAdd    = Bits(OUTPUT, 4)
-        val latchMulAddA_0 = Bool(OUTPUT)
-        val mulAddA_0      = UInt(OUTPUT, 54)
-        val latchMulAddB_0 = Bool(OUTPUT)
-        val mulAddB_0      = UInt(OUTPUT, 54)
-        val mulAddC_2      = UInt(OUTPUT, 105)
-        val mulAddResult_3 = UInt(INPUT, 105)
+        val usingMulAdd    = Output(Bits(4.W))
+        val latchMulAddA_0 = Output(Bool())
+        val mulAddA_0      = Output(UInt(54.W))
+        val latchMulAddB_0 = Output(Bool())
+        val mulAddB_0      = Output(UInt(54.W))
+        val mulAddC_2      = Output(UInt(105.W))
+        val mulAddResult_3 = Input(UInt(105.W))
         /*--------------------------------------------------------------------
         *--------------------------------------------------------------------*/
-        val rawOutValid_div  = Bool(OUTPUT)
-        val rawOutValid_sqrt = Bool(OUTPUT)
-        val roundingModeOut  = UInt(OUTPUT, 3)
-        val invalidExc       = Bool(OUTPUT)
-        val infiniteExc      = Bool(OUTPUT)
-        val rawOut = new RawFloat(11, 55).asOutput
+        val rawOutValid_div  = Output(Bool())
+        val rawOutValid_sqrt = Output(Bool())
+        val roundingModeOut  = Output(UInt(3.W))
+        val invalidExc       = Output(Bool())
+        val infiniteExc      = Output(Bool())
+        val rawOut = Output(new RawFloat(11, 55))
     })
 
     /*------------------------------------------------------------------------
     *------------------------------------------------------------------------*/
-    val cycleNum_A      = Reg(init = UInt(0, 3))
-    val cycleNum_B      = Reg(init = UInt(0, 4))
-    val cycleNum_C      = Reg(init = UInt(0, 3))
-    val cycleNum_E      = Reg(init = UInt(0, 3))
+    val cycleNum_A      = Reg(0.U(3.W))
+    val cycleNum_B      = Reg(0.U(4.W))
+    val cycleNum_C      = Reg(0.U(3.W))
+    val cycleNum_E      = Reg(0.U(3.W))
 
-    val valid_PA        = Reg(init = Bool(false))
+    val valid_PA        = Reg(false.B)
     val sqrtOp_PA       = Reg(Bool())
     val majorExc_PA     = Reg(Bool())
 //*** REDUCE 3 BITS TO 2-BIT CODE:
@@ -95,12 +96,12 @@ class DivSqrtRecF64ToRaw_mulAddZ31(options: Int) extends Module
     val isInf_PA        = Reg(Bool())
     val isZero_PA       = Reg(Bool())
     val sign_PA         = Reg(Bool())
-    val sExp_PA         = Reg(SInt(width = 13))
-    val fractB_PA       = Reg(UInt(width = 52))
-    val fractA_PA       = Reg(UInt(width = 52))
-    val roundingMode_PA = Reg(UInt(width = 3))
+    val sExp_PA         = Reg(SInt(13.W))
+    val fractB_PA       = Reg(UInt(52.W))
+    val fractA_PA       = Reg(UInt(52.W))
+    val roundingMode_PA = Reg(UInt(3.W))
 
-    val valid_PB        = Reg(init = Bool(false))
+    val valid_PB        = RegInit(false.B)
     val sqrtOp_PB       = Reg(Bool())
     val majorExc_PB     = Reg(Bool())
 //*** REDUCE 3 BITS TO 2-BIT CODE:
@@ -108,12 +109,12 @@ class DivSqrtRecF64ToRaw_mulAddZ31(options: Int) extends Module
     val isInf_PB        = Reg(Bool())
     val isZero_PB       = Reg(Bool())
     val sign_PB         = Reg(Bool())
-    val sExp_PB         = Reg(SInt(width = 13))
-    val bit0FractA_PB   = Reg(UInt(width = 1))
-    val fractB_PB       = Reg(UInt(width = 52))
-    val roundingMode_PB = Reg(UInt(width = 3))
+    val sExp_PB         = Reg(SInt(13.W))
+    val bit0FractA_PB   = Reg(UInt(1.W))
+    val fractB_PB       = Reg(UInt(52.W))
+    val roundingMode_PB = Reg(UInt(3.W))
 
-    val valid_PC        = Reg(init = Bool(false))
+    val valid_PC        = RegInit(false.B)
     val sqrtOp_PC       = Reg(Bool())
     val majorExc_PC     = Reg(Bool())
 //*** REDUCE 3 BITS TO 2-BIT CODE:
@@ -121,26 +122,26 @@ class DivSqrtRecF64ToRaw_mulAddZ31(options: Int) extends Module
     val isInf_PC        = Reg(Bool())
     val isZero_PC       = Reg(Bool())
     val sign_PC         = Reg(Bool())
-    val sExp_PC         = Reg(SInt(width = 13))
-    val bit0FractA_PC   = Reg(UInt(width = 1))
-    val fractB_PC       = Reg(UInt(width = 52))
-    val roundingMode_PC = Reg(UInt(width = 3))
+    val sExp_PC         = Reg(SInt(13.W))
+    val bit0FractA_PC   = Reg(UInt(1.W))
+    val fractB_PC       = Reg(UInt(52.W))
+    val roundingMode_PC = Reg(UInt(3.W))
 
-    val fractR0_A       = Reg(UInt(width = 9))
+    val fractR0_A       = Reg(UInt(9.W))
 //*** COMBINE 'hiSqrR0_A_sqrt' AND 'partNegSigma0_A'?
-    val hiSqrR0_A_sqrt  = Reg(UInt(width = 10))
-    val partNegSigma0_A = Reg(UInt(width = 21))
-    val nextMulAdd9A_A  = Reg(UInt(width = 9))
-    val nextMulAdd9B_A  = Reg(UInt(width = 9))
-    val ER1_B_sqrt      = Reg(UInt(width = 17))
+    val hiSqrR0_A_sqrt  = Reg(UInt(10.W))
+    val partNegSigma0_A = Reg(UInt(21.W))
+    val nextMulAdd9A_A  = Reg(UInt(9.W))
+    val nextMulAdd9B_A  = Reg(UInt(9.W))
+    val ER1_B_sqrt      = Reg(UInt(17.W))
 
-    val ESqrR1_B_sqrt   = Reg(UInt(width = 32))
-    val sigX1_B         = Reg(UInt(width = 58))
-    val sqrSigma1_C     = Reg(UInt(width = 33))
-    val sigXN_C         = Reg(UInt(width = 58))
-    val u_C_sqrt        = Reg(UInt(width = 31))
+    val ESqrR1_B_sqrt   = Reg(UInt(32.W))
+    val sigX1_B         = Reg(UInt(58.W))
+    val sqrSigma1_C     = Reg(UInt(33.W))
+    val sigXN_C         = Reg(UInt(58.W))
+    val u_C_sqrt        = Reg(UInt(31.W))
     val E_E_div         = Reg(Bool())
-    val sigT_E          = Reg(UInt(width = 54))
+    val sigT_E          = Reg(UInt(54.W))
     val isNegRemT_E     = Reg(Bool())
     val isZeroRemT_E    = Reg(Bool())
 
@@ -194,13 +195,13 @@ class DivSqrtRecF64ToRaw_mulAddZ31(options: Int) extends Module
     val normalCase_S = Mux(io.sqrtOp, normalCase_S_sqrt, normalCase_S_div)
 
     val sExpQuot_S_div =
-        rawA_S.sExp +& Cat(rawB_S.sExp(11), ~rawB_S.sExp(10, 0)).asSInt
+        rawA_S.sExp +& (rawB_S.sExp(11) ## ~rawB_S.sExp(10, 0)).asSInt
 //*** IS THIS OPTIMAL?:
     val sSatExpQuot_S_div =
-        Cat(Mux((SInt(7<<9) <= sExpQuot_S_div),
-                UInt(6),
-                sExpQuot_S_div(12, 9)
-            ),
+        (Mux(((7<<9).S <= sExpQuot_S_div),
+            6.U,
+            sExpQuot_S_div(12, 9)
+            ) ##
             sExpQuot_S_div(8, 0)
         ).asSInt
 
@@ -213,24 +214,24 @@ class DivSqrtRecF64ToRaw_mulAddZ31(options: Int) extends Module
 
     /*------------------------------------------------------------------------
     *------------------------------------------------------------------------*/
-    when (entering_PA_normalCase || (cycleNum_A =/= UInt(0))) {
+    when (entering_PA_normalCase || (cycleNum_A =/= 0.U)) {
         cycleNum_A :=
-            Mux(entering_PA_normalCase_div,  UInt(3),              UInt(0)) |
-            Mux(entering_PA_normalCase_sqrt, UInt(6),              UInt(0)) |
-            Mux(! entering_PA_normalCase,    cycleNum_A - UInt(1), UInt(0))
+            Mux(entering_PA_normalCase_div,  3.U,              0.U) |
+            Mux(entering_PA_normalCase_sqrt, 6.U,              0.U) |
+            Mux(! entering_PA_normalCase,    cycleNum_A - 1.U, 0.U)
     }
 
     val cyc_A7_sqrt = entering_PA_normalCase_sqrt
-    val cyc_A6_sqrt = (cycleNum_A === UInt(6))
-    val cyc_A5_sqrt = (cycleNum_A === UInt(5))
-    val cyc_A4_sqrt = (cycleNum_A === UInt(4))
+    val cyc_A6_sqrt = (cycleNum_A === 6.U)
+    val cyc_A5_sqrt = (cycleNum_A === 5.U)
+    val cyc_A4_sqrt = (cycleNum_A === 4.U)
 
     val cyc_A4_div = entering_PA_normalCase_div
 
     val cyc_A4 = cyc_A4_sqrt || cyc_A4_div
-    val cyc_A3 = (cycleNum_A === UInt(3))
-    val cyc_A2 = (cycleNum_A === UInt(2))
-    val cyc_A1 = (cycleNum_A === UInt(1))
+    val cyc_A3 = (cycleNum_A === 3.U)
+    val cyc_A2 = (cycleNum_A === 2.U)
+    val cyc_A1 = (cycleNum_A === 1.U)
 
     val cyc_A3_div = cyc_A3 && ! sqrtOp_PA
     val cyc_A2_div = cyc_A2 && ! sqrtOp_PA
@@ -240,25 +241,25 @@ class DivSqrtRecF64ToRaw_mulAddZ31(options: Int) extends Module
     val cyc_A2_sqrt = cyc_A2 && sqrtOp_PA
     val cyc_A1_sqrt = cyc_A1 && sqrtOp_PA
 
-    when (cyc_A1 || (cycleNum_B =/= UInt(0))) {
+    when (cyc_A1 || (cycleNum_B =/= 0.U)) {
         cycleNum_B :=
             Mux(cyc_A1,
-                Mux(sqrtOp_PA, UInt(10), UInt(6)),
-                cycleNum_B - UInt(1)
+                Mux(sqrtOp_PA, 10.U, 6.U),
+                cycleNum_B - 1.U
             )
     }
 
-    val cyc_B10_sqrt = (cycleNum_B === UInt(10))
-    val cyc_B9_sqrt  = (cycleNum_B === UInt(9))
-    val cyc_B8_sqrt  = (cycleNum_B === UInt(8))
-    val cyc_B7_sqrt  = (cycleNum_B === UInt(7))
+    val cyc_B10_sqrt = (cycleNum_B === 10.U)
+    val cyc_B9_sqrt  = (cycleNum_B === 9.U)
+    val cyc_B8_sqrt  = (cycleNum_B === 8.U)
+    val cyc_B7_sqrt  = (cycleNum_B === 7.U)
 
-    val cyc_B6 = (cycleNum_B === UInt(6))
-    val cyc_B5 = (cycleNum_B === UInt(5))
-    val cyc_B4 = (cycleNum_B === UInt(4))
-    val cyc_B3 = (cycleNum_B === UInt(3))
-    val cyc_B2 = (cycleNum_B === UInt(2))
-    val cyc_B1 = (cycleNum_B === UInt(1))
+    val cyc_B6 = (cycleNum_B === 6.U)
+    val cyc_B5 = (cycleNum_B === 5.U)
+    val cyc_B4 = (cycleNum_B === 4.U)
+    val cyc_B3 = (cycleNum_B === 3.U)
+    val cyc_B2 = (cycleNum_B === 2.U)
+    val cyc_B1 = (cycleNum_B === 1.U)
 
     val cyc_B6_div = cyc_B6 && valid_PA && ! sqrtOp_PA
     val cyc_B5_div = cyc_B5 && valid_PA && ! sqrtOp_PA
@@ -274,18 +275,18 @@ class DivSqrtRecF64ToRaw_mulAddZ31(options: Int) extends Module
     val cyc_B2_sqrt = cyc_B2 && sqrtOp_PB
     val cyc_B1_sqrt = cyc_B1 && sqrtOp_PB
 
-    when (cyc_B1 || (cycleNum_C =/= UInt(0))) {
+    when (cyc_B1 || (cycleNum_C =/= 0.U)) {
         cycleNum_C :=
-            Mux(cyc_B1, Mux(sqrtOp_PB, UInt(6), UInt(5)), cycleNum_C - UInt(1))
+            Mux(cyc_B1, Mux(sqrtOp_PB, 6.U, 5.U), cycleNum_C - 1.U)
     }
 
-    val cyc_C6_sqrt = (cycleNum_C === UInt(6))
+    val cyc_C6_sqrt = (cycleNum_C === 6.U)
 
-    val cyc_C5 = (cycleNum_C === UInt(5))
-    val cyc_C4 = (cycleNum_C === UInt(4))
-    val cyc_C3 = (cycleNum_C === UInt(3))
-    val cyc_C2 = (cycleNum_C === UInt(2))
-    val cyc_C1 = (cycleNum_C === UInt(1))
+    val cyc_C5 = (cycleNum_C === 5.U)
+    val cyc_C4 = (cycleNum_C === 4.U)
+    val cyc_C3 = (cycleNum_C === 3.U)
+    val cyc_C2 = (cycleNum_C === 2.U)
+    val cyc_C1 = (cycleNum_C === 1.U)
 
     val cyc_C5_div = cyc_C5 && ! sqrtOp_PB
     val cyc_C4_div = cyc_C4 && ! sqrtOp_PB
@@ -299,14 +300,14 @@ class DivSqrtRecF64ToRaw_mulAddZ31(options: Int) extends Module
     val cyc_C2_sqrt = cyc_C2 && sqrtOp_PC
     val cyc_C1_sqrt = cyc_C1 && sqrtOp_PC
 
-    when (cyc_C1 || (cycleNum_E =/= UInt(0))) {
-        cycleNum_E := Mux(cyc_C1, UInt(4), cycleNum_E - UInt(1))
+    when (cyc_C1 || (cycleNum_E =/= 0.U)) {
+        cycleNum_E := Mux(cyc_C1, 4.U, cycleNum_E - 1.U)
     }
 
-    val cyc_E4 = (cycleNum_E === UInt(4))
-    val cyc_E3 = (cycleNum_E === UInt(3))
-    val cyc_E2 = (cycleNum_E === UInt(2))
-    val cyc_E1 = (cycleNum_E === UInt(1))
+    val cyc_E4 = (cycleNum_E === 4.U)
+    val cyc_E3 = (cycleNum_E === 3.U)
+    val cyc_E2 = (cycleNum_E === 2.U)
+    val cyc_E1 = (cycleNum_E === 1.U)
 
     val cyc_E4_div = cyc_E4 && ! sqrtOp_PC
     val cyc_E3_div = cyc_E3 && ! sqrtOp_PC
@@ -344,8 +345,8 @@ class DivSqrtRecF64ToRaw_mulAddZ31(options: Int) extends Module
     }
 
     val normalCase_PA = ! isNaN_PA && ! isInf_PA && ! isZero_PA
-    val sigA_PA = Cat(UInt(1, 1), fractA_PA)
-    val sigB_PA = Cat(UInt(1, 1), fractB_PA)
+    val sigA_PA = 1.U(1.W) ## fractA_PA
+    val sigB_PA = 1.U(1.W) ## fractB_PA
 
     val valid_normalCase_leaving_PA = cyc_B4_div || cyc_B7_sqrt
     val valid_leaving_PA =
@@ -415,7 +416,7 @@ class DivSqrtRecF64ToRaw_mulAddZ31(options: Int) extends Module
     }
 
     val normalCase_PC = ! isNaN_PC && ! isInf_PC && ! isZero_PC
-    val sigB_PC = Cat(UInt(1, 1), fractB_PC)
+    val sigB_PC = 1.U(1.W) ## fractB_PC
 
     val valid_leaving_PC = ! normalCase_PC || cyc_E1
     leaving_PC := valid_PC && valid_leaving_PC
@@ -436,36 +437,36 @@ class DivSqrtRecF64ToRaw_mulAddZ31(options: Int) extends Module
     /*------------------------------------------------------------------------
     | Macrostage A, built around a 9x9-bit multiplier-adder.
     *------------------------------------------------------------------------*/
-    val zFractB_A4_div = Mux(cyc_A4_div, rawB_S.sig(51, 0), UInt(0))
+    val zFractB_A4_div = Mux(cyc_A4_div, rawB_S.sig(51, 0), 0.U)
 
-    val zLinPiece_0_A4_div = cyc_A4_div && (rawB_S.sig(51, 49) === UInt(0))
-    val zLinPiece_1_A4_div = cyc_A4_div && (rawB_S.sig(51, 49) === UInt(1))
-    val zLinPiece_2_A4_div = cyc_A4_div && (rawB_S.sig(51, 49) === UInt(2))
-    val zLinPiece_3_A4_div = cyc_A4_div && (rawB_S.sig(51, 49) === UInt(3))
-    val zLinPiece_4_A4_div = cyc_A4_div && (rawB_S.sig(51, 49) === UInt(4))
-    val zLinPiece_5_A4_div = cyc_A4_div && (rawB_S.sig(51, 49) === UInt(5))
-    val zLinPiece_6_A4_div = cyc_A4_div && (rawB_S.sig(51, 49) === UInt(6))
-    val zLinPiece_7_A4_div = cyc_A4_div && (rawB_S.sig(51, 49) === UInt(7))
+    val zLinPiece_0_A4_div = cyc_A4_div && (rawB_S.sig(51, 49) === 0.U)
+    val zLinPiece_1_A4_div = cyc_A4_div && (rawB_S.sig(51, 49) === 1.U)
+    val zLinPiece_2_A4_div = cyc_A4_div && (rawB_S.sig(51, 49) === 2.U)
+    val zLinPiece_3_A4_div = cyc_A4_div && (rawB_S.sig(51, 49) === 3.U)
+    val zLinPiece_4_A4_div = cyc_A4_div && (rawB_S.sig(51, 49) === 4.U)
+    val zLinPiece_5_A4_div = cyc_A4_div && (rawB_S.sig(51, 49) === 5.U)
+    val zLinPiece_6_A4_div = cyc_A4_div && (rawB_S.sig(51, 49) === 6.U)
+    val zLinPiece_7_A4_div = cyc_A4_div && (rawB_S.sig(51, 49) === 7.U)
     val zK1_A4_div =
-        Mux(zLinPiece_0_A4_div, UInt("h1C7"), UInt(0)) |
-        Mux(zLinPiece_1_A4_div, UInt("h16C"), UInt(0)) |
-        Mux(zLinPiece_2_A4_div, UInt("h12A"), UInt(0)) |
-        Mux(zLinPiece_3_A4_div, UInt("h0F8"), UInt(0)) |
-        Mux(zLinPiece_4_A4_div, UInt("h0D2"), UInt(0)) |
-        Mux(zLinPiece_5_A4_div, UInt("h0B4"), UInt(0)) |
-        Mux(zLinPiece_6_A4_div, UInt("h09C"), UInt(0)) |
-        Mux(zLinPiece_7_A4_div, UInt("h089"), UInt(0))
+        Mux(zLinPiece_0_A4_div, "h1C7".U, 0.U) |
+        Mux(zLinPiece_1_A4_div, "h16C".U, 0.U) |
+        Mux(zLinPiece_2_A4_div, "h12A".U, 0.U) |
+        Mux(zLinPiece_3_A4_div, "h0F8".U, 0.U) |
+        Mux(zLinPiece_4_A4_div, "h0D2".U, 0.U) |
+        Mux(zLinPiece_5_A4_div, "h0B4".U, 0.U) |
+        Mux(zLinPiece_6_A4_div, "h09C".U, 0.U) |
+        Mux(zLinPiece_7_A4_div, "h089".U, 0.U)
     val zComplFractK0_A4_div =
-        Mux(zLinPiece_0_A4_div, ~UInt("hFE3", 12), UInt(0)) |
-        Mux(zLinPiece_1_A4_div, ~UInt("hC5D", 12), UInt(0)) |
-        Mux(zLinPiece_2_A4_div, ~UInt("h98A", 12), UInt(0)) |
-        Mux(zLinPiece_3_A4_div, ~UInt("h739", 12), UInt(0)) |
-        Mux(zLinPiece_4_A4_div, ~UInt("h54B", 12), UInt(0)) |
-        Mux(zLinPiece_5_A4_div, ~UInt("h3A9", 12), UInt(0)) |
-        Mux(zLinPiece_6_A4_div, ~UInt("h242", 12), UInt(0)) |
-        Mux(zLinPiece_7_A4_div, ~UInt("h10B", 12), UInt(0))
+        Mux(zLinPiece_0_A4_div, ~"hFE3".U(12.W), 0.U) |
+        Mux(zLinPiece_1_A4_div, ~"hC5D".U(12.W), 0.U) |
+        Mux(zLinPiece_2_A4_div, ~"h98A".U(12.W), 0.U) |
+        Mux(zLinPiece_3_A4_div, ~"h739".U(12.W), 0.U) |
+        Mux(zLinPiece_4_A4_div, ~"h54B".U(12.W), 0.U) |
+        Mux(zLinPiece_5_A4_div, ~"h3A9".U(12.W), 0.U) |
+        Mux(zLinPiece_6_A4_div, ~"h242".U(12.W), 0.U) |
+        Mux(zLinPiece_7_A4_div, ~"h10B".U(12.W), 0.U)
 
-    val zFractB_A7_sqrt = Mux(cyc_A7_sqrt, rawB_S.sig(51, 0), UInt(0))
+    val zFractB_A7_sqrt = Mux(cyc_A7_sqrt, rawB_S.sig(51, 0), 0.U)
 
     val zQuadPiece_0_A7_sqrt =
         cyc_A7_sqrt && ! rawB_S.sExp(0) && ! rawB_S.sig(51)
@@ -475,66 +476,66 @@ class DivSqrtRecF64ToRaw_mulAddZ31(options: Int) extends Module
         cyc_A7_sqrt &&   rawB_S.sExp(0) && ! rawB_S.sig(51)
     val zQuadPiece_3_A7_sqrt = cyc_A7_sqrt && rawB_S.sExp(0) && rawB_S.sig(51)
     val zK2_A7_sqrt =
-        Mux(zQuadPiece_0_A7_sqrt, UInt("h1C8"), UInt(0)) |
-        Mux(zQuadPiece_1_A7_sqrt, UInt("h0C1"), UInt(0)) |
-        Mux(zQuadPiece_2_A7_sqrt, UInt("h143"), UInt(0)) |
-        Mux(zQuadPiece_3_A7_sqrt, UInt("h089"), UInt(0))
+        Mux(zQuadPiece_0_A7_sqrt, "h1C8".U, 0.U) |
+        Mux(zQuadPiece_1_A7_sqrt, "h0C1".U, 0.U) |
+        Mux(zQuadPiece_2_A7_sqrt, "h143".U, 0.U) |
+        Mux(zQuadPiece_3_A7_sqrt, "h089".U, 0.U)
     val zComplK1_A7_sqrt =
-        Mux(zQuadPiece_0_A7_sqrt, ~UInt("h3D0", 10), UInt(0)) |
-        Mux(zQuadPiece_1_A7_sqrt, ~UInt("h220", 10), UInt(0)) |
-        Mux(zQuadPiece_2_A7_sqrt, ~UInt("h2B2", 10), UInt(0)) |
-        Mux(zQuadPiece_3_A7_sqrt, ~UInt("h181", 10), UInt(0))
+        Mux(zQuadPiece_0_A7_sqrt, ~"h3D0".U(10.W), 0.U) |
+        Mux(zQuadPiece_1_A7_sqrt, ~"h220".U(10.W), 0.U) |
+        Mux(zQuadPiece_2_A7_sqrt, ~"h2B2".U(10.W), 0.U) |
+        Mux(zQuadPiece_3_A7_sqrt, ~"h181".U(10.W), 0.U)
 
     val zQuadPiece_0_A6_sqrt = cyc_A6_sqrt && ! sExp_PA(0) && ! sigB_PA(51)
     val zQuadPiece_1_A6_sqrt = cyc_A6_sqrt && ! sExp_PA(0) &&   sigB_PA(51)
     val zQuadPiece_2_A6_sqrt = cyc_A6_sqrt &&   sExp_PA(0) && ! sigB_PA(51)
     val zQuadPiece_3_A6_sqrt = cyc_A6_sqrt &&   sExp_PA(0) &&   sigB_PA(51)
     val zComplFractK0_A6_sqrt =
-        Mux(zQuadPiece_0_A6_sqrt, ~UInt("h1FE5", 13), UInt(0)) |
-        Mux(zQuadPiece_1_A6_sqrt, ~UInt("h1435", 13), UInt(0)) |
-        Mux(zQuadPiece_2_A6_sqrt, ~UInt("h0D2C", 13), UInt(0)) |
-        Mux(zQuadPiece_3_A6_sqrt, ~UInt("h04E8", 13), UInt(0))
+        Mux(zQuadPiece_0_A6_sqrt, ~"h1FE5".U(13.W), 0.U) |
+        Mux(zQuadPiece_1_A6_sqrt, ~"h1435".U(13.W), 0.U) |
+        Mux(zQuadPiece_2_A6_sqrt, ~"h0D2C".U(13.W), 0.U) |
+        Mux(zQuadPiece_3_A6_sqrt, ~"h04E8".U(13.W), 0.U)
 
     val mulAdd9A_A =
         zFractB_A4_div(48, 40) | zK2_A7_sqrt |
-            Mux(! cyc_S, nextMulAdd9A_A, UInt(0))
+            Mux(! cyc_S, nextMulAdd9A_A, 0.U)
     val mulAdd9B_A =
         zK1_A4_div | zFractB_A7_sqrt(50, 42) |
-            Mux(! cyc_S, nextMulAdd9B_A, UInt(0))
+            Mux(! cyc_S, nextMulAdd9B_A, 0.U)
     val mulAdd9C_A =
 //*** ADJUST CONSTANTS SO 'Fill'S AREN'T NEEDED:
-        Cat(zComplK1_A7_sqrt,                  Fill(10, cyc_A7_sqrt)) |
+        zComplK1_A7_sqrt ##                  Fill(10, cyc_A7_sqrt) |
         Cat(cyc_A6_sqrt, zComplFractK0_A6_sqrt, Fill(6, cyc_A6_sqrt)) |
         Cat(cyc_A4_div,  zComplFractK0_A4_div,  Fill(8, cyc_A4_div )) |
-        Mux(cyc_A5_sqrt,     UInt(1<<18) +& (fractR0_A<<10), UInt(0)) |
-        Mux(cyc_A4_sqrt && ! hiSqrR0_A_sqrt(9), UInt(1<<10), UInt(0)) |
+        Mux(cyc_A5_sqrt,     (1<<18).U +& (fractR0_A<<10), 0.U) |
+        Mux(cyc_A4_sqrt && ! hiSqrR0_A_sqrt(9), (1<<10).U, 0.U) |
         Mux((cyc_A4_sqrt && hiSqrR0_A_sqrt(9)) || cyc_A3_div,
-            sigB_PA(46, 26) + UInt(1<<10),
-            UInt(0)
+            sigB_PA(46, 26) + (1<<10).U,
+            0.U
         ) |
-        Mux(cyc_A3_sqrt || cyc_A2, partNegSigma0_A, UInt(0)) |
-        Mux(cyc_A1_sqrt,           fractR0_A<<16,   UInt(0)) |
-        Mux(cyc_A1_div,            fractR0_A<<15,   UInt(0))
+        Mux(cyc_A3_sqrt || cyc_A2, partNegSigma0_A, 0.U) |
+        Mux(cyc_A1_sqrt,           fractR0_A<<16,   0.U) |
+        Mux(cyc_A1_div,            fractR0_A<<15,   0.U)
     val loMulAdd9Out_A = mulAdd9A_A * mulAdd9B_A +& mulAdd9C_A(17, 0)
     val mulAdd9Out_A =
         Cat(Mux(loMulAdd9Out_A(18),
-                mulAdd9C_A(24, 18) + UInt(1),
+                mulAdd9C_A(24, 18) + 1.U,
                 mulAdd9C_A(24, 18)
             ),
             loMulAdd9Out_A(17, 0)
         )
 
     val zFractR0_A6_sqrt =
-        Mux(cyc_A6_sqrt && mulAdd9Out_A(19), ~(mulAdd9Out_A>>10), UInt(0))
+        Mux(cyc_A6_sqrt && mulAdd9Out_A(19), ~(mulAdd9Out_A>>10), 0.U)
     /*------------------------------------------------------------------------
     | ('sqrR0_A5_sqrt' is usually >= 1, but not always.)
     *------------------------------------------------------------------------*/
     val sqrR0_A5_sqrt = Mux(sExp_PA(0), mulAdd9Out_A<<1, mulAdd9Out_A)
     val zFractR0_A4_div =
-        Mux(cyc_A4_div && mulAdd9Out_A(20), ~(mulAdd9Out_A>>11), UInt(0))
+        Mux(cyc_A4_div && mulAdd9Out_A(20), ~(mulAdd9Out_A>>11), 0.U)
     val zSigma0_A2 =
-        Mux(cyc_A2 && mulAdd9Out_A(11), ~(mulAdd9Out_A>>2), UInt(0))
-    val r1_A1 = UInt(1<<15) | Mux(sqrtOp_PA, mulAdd9Out_A>>10, mulAdd9Out_A>>9)
+        Mux(cyc_A2 && mulAdd9Out_A(11), ~(mulAdd9Out_A>>2), 0.U)
+    val r1_A1 = (1<<15).U | Mux(sqrtOp_PA, mulAdd9Out_A>>10, mulAdd9Out_A>>9)
     val ER1_A1_sqrt = Mux(sExp_PA(0), r1_A1<<1, r1_A1)
 
     when (cyc_A6_sqrt || cyc_A4_div) {
@@ -550,21 +551,21 @@ class DivSqrtRecF64ToRaw_mulAddZ31(options: Int) extends Module
         cyc_A7_sqrt || cyc_A6_sqrt || cyc_A5_sqrt || cyc_A4 || cyc_A3 || cyc_A2
     ) {
         nextMulAdd9A_A :=
-            Mux(cyc_A7_sqrt,           ~mulAdd9Out_A>>11, UInt(0)) |
+            Mux(cyc_A7_sqrt,           ~mulAdd9Out_A>>11, 0.U) |
             zFractR0_A6_sqrt                                       |
-            Mux(cyc_A4_sqrt,           sigB_PA(43, 35),   UInt(0)) |
+            Mux(cyc_A4_sqrt,           sigB_PA(43, 35),   0.U) |
             zFractB_A4_div(43, 35)                                 |
-            Mux(cyc_A5_sqrt || cyc_A3, sigB_PA(52, 44),   UInt(0)) |
+            Mux(cyc_A5_sqrt || cyc_A3, sigB_PA(52, 44),   0.U) |
             zSigma0_A2
     }
     when (cyc_A7_sqrt || cyc_A6_sqrt || cyc_A5_sqrt || cyc_A4 || cyc_A2) {
         nextMulAdd9B_A :=
             zFractB_A7_sqrt(50, 42)                                     |
             zFractR0_A6_sqrt                                            |
-            Mux(cyc_A5_sqrt, sqrR0_A5_sqrt(9, 1),              UInt(0)) |
+            Mux(cyc_A5_sqrt, sqrR0_A5_sqrt(9, 1),              0.U) |
             zFractR0_A4_div                                             |
-            Mux(cyc_A4_sqrt, hiSqrR0_A_sqrt(8, 0),             UInt(0)) |
-            Mux(cyc_A2,      Cat(UInt(1, 1), fractR0_A(8, 1)), UInt(0))
+            Mux(cyc_A4_sqrt, hiSqrR0_A_sqrt(8, 0),             0.U) |
+            Mux(cyc_A2,      Cat(1.U(1.W), fractR0_A(8, 1)), 0.U)
     }
     when (cyc_A1_sqrt) {
         ER1_B_sqrt := ER1_A1_sqrt
@@ -576,26 +577,26 @@ class DivSqrtRecF64ToRaw_mulAddZ31(options: Int) extends Module
         cyc_A1 || cyc_B7_sqrt || cyc_B6_div || cyc_B4 || cyc_B3 ||
             cyc_C6_sqrt || cyc_C4 || cyc_C1
     io.mulAddA_0 :=
-        Mux(cyc_A1_sqrt,               ER1_A1_sqrt<<36,  UInt(0)) | // 52:36
-        Mux(cyc_B7_sqrt || cyc_A1_div, sigB_PA,          UInt(0)) | // 52:0
-        Mux(cyc_B6_div,                sigA_PA,          UInt(0)) | // 52:0
+        Mux(cyc_A1_sqrt,               ER1_A1_sqrt<<36,  0.U) | // 52:36
+        Mux(cyc_B7_sqrt || cyc_A1_div, sigB_PA,          0.U) | // 52:0
+        Mux(cyc_B6_div,                sigA_PA,          0.U) | // 52:0
         zSigma1_B4(45, 12)                                        | // 33:0
 //*** ONLY 30 BITS NEEDED IN CYCLE C6:
-        Mux(cyc_B3 || cyc_C6_sqrt, sigXNU_B3_CX(57, 12), UInt(0)) | // 45:0
-        Mux(cyc_C4_div,            sigXN_C(57, 25)<<13,  UInt(0)) | // 45:13
-        Mux(cyc_C4_sqrt,           u_C_sqrt<<15,         UInt(0)) | // 45:15
-        Mux(cyc_C1_div,            sigB_PC,              UInt(0)) | // 52:0
+        Mux(cyc_B3 || cyc_C6_sqrt, sigXNU_B3_CX(57, 12), 0.U) | // 45:0
+        Mux(cyc_C4_div,            sigXN_C(57, 25)<<13,  0.U) | // 45:13
+        Mux(cyc_C4_sqrt,           u_C_sqrt<<15,         0.U) | // 45:15
+        Mux(cyc_C1_div,            sigB_PC,              0.U) | // 52:0
         zComplSigT_C1_sqrt                                          // 53:0
     io.latchMulAddB_0 :=
         cyc_A1 || cyc_B7_sqrt || cyc_B6_sqrt || cyc_B4 ||
             cyc_C6_sqrt || cyc_C4 || cyc_C1
     io.mulAddB_0 :=
-        Mux(cyc_A1,      r1_A1<<36,          UInt(0)) |  // 51:36
-        Mux(cyc_B7_sqrt, ESqrR1_B_sqrt<<19,  UInt(0)) |  // 50:19
-        Mux(cyc_B6_sqrt, ER1_B_sqrt<<36,     UInt(0)) |  // 52:36
+        Mux(cyc_A1,      r1_A1<<36,          0.U) |  // 51:36
+        Mux(cyc_B7_sqrt, ESqrR1_B_sqrt<<19,  0.U) |  // 50:19
+        Mux(cyc_B6_sqrt, ER1_B_sqrt<<36,     0.U) |  // 52:36
         zSigma1_B4                                    |  // 45:0
-        Mux(cyc_C6_sqrt, sqrSigma1_C(30, 1), UInt(0)) |  // 29:0
-        Mux(cyc_C4,      sqrSigma1_C,        UInt(0)) |  // 32:0
+        Mux(cyc_C6_sqrt, sqrSigma1_C(30, 1), 0.U) |  // 29:0
+        Mux(cyc_C4,      sqrSigma1_C,        0.U) |  // 32:0
         zComplSigT_C1                                    // 53:0
 
     io.usingMulAdd :=
@@ -615,32 +616,32 @@ class DivSqrtRecF64ToRaw_mulAddZ31(options: Int) extends Module
         )
 
     io.mulAddC_2 :=
-        Mux(cyc_B1,                  sigX1_B<<47,       UInt(0)) |
-        Mux(cyc_C6_sqrt,             sigX1_B<<46,       UInt(0)) |
-        Mux(cyc_C4_sqrt || cyc_C2,   sigXN_C<<47,       UInt(0)) |
-        Mux(cyc_E3_div && ! E_E_div, bit0FractA_PC<<53, UInt(0)) |
+        Mux(cyc_B1,                  sigX1_B<<47,       0.U) |
+        Mux(cyc_C6_sqrt,             sigX1_B<<46,       0.U) |
+        Mux(cyc_C4_sqrt || cyc_C2,   sigXN_C<<47,       0.U) |
+        Mux(cyc_E3_div && ! E_E_div, bit0FractA_PC<<53, 0.U) |
         Mux(cyc_E3_sqrt,
             (Mux(sExp_PC(0),
                  sigB_PC(0)<<1,
-                 Cat(sigB_PC(1) ^ sigB_PC(0), sigB_PC(0))
+                 sigB_PC(1) ^ sigB_PC(0) ## sigB_PC(0)
              ) ^ ((~ sigT_E(0))<<1)
             )<<54,
-            UInt(0)
+            0.U
         )
 
     val ESqrR1_B8_sqrt = io.mulAddResult_3(103, 72)
-    zSigma1_B4 := Mux(cyc_B4, ~io.mulAddResult_3(90, 45), UInt(0))
+    zSigma1_B4 := Mux(cyc_B4, ~io.mulAddResult_3(90, 45), 0.U)
     val sqrSigma1_B1 = io.mulAddResult_3(79, 47)
     sigXNU_B3_CX := io.mulAddResult_3(104, 47)   // x1, x2, u (sqrt), xT'
     val E_C1_div = ! io.mulAddResult_3(104)
     zComplSigT_C1 :=
         Mux((cyc_C1_div && ! E_C1_div) || cyc_C1_sqrt,
             ~io.mulAddResult_3(104, 51),
-            UInt(0)
+            0.U
         ) |
-        Mux(cyc_C1_div && E_C1_div, ~io.mulAddResult_3(102, 50), UInt(0))
+        Mux(cyc_C1_div && E_C1_div, ~io.mulAddResult_3(102, 50), 0.U)
     zComplSigT_C1_sqrt :=
-        Mux(cyc_C1_sqrt, ~io.mulAddResult_3(104, 51), UInt(0))
+        Mux(cyc_C1_sqrt, ~io.mulAddResult_3(104, 51), 0.U)
     /*------------------------------------------------------------------------
     | (For square root, 'sigT_C1' will usually be >= 1, but not always.)
     *------------------------------------------------------------------------*/
@@ -671,8 +672,8 @@ class DivSqrtRecF64ToRaw_mulAddZ31(options: Int) extends Module
     when (cyc_E2) {
         isNegRemT_E := Mux(sqrtOp_PC,  remT_E2(55),  remT_E2(53))
         isZeroRemT_E :=
-            (remT_E2(53, 0) === UInt(0)) &&
-                (! sqrtOp_PC || (remT_E2(55, 54) === UInt(0)))
+            (remT_E2(53, 0) === 0.U) &&
+                (! sqrtOp_PC || (remT_E2(55, 54) === 0.U))
     }
 
     /*------------------------------------------------------------------------
@@ -690,8 +691,8 @@ class DivSqrtRecF64ToRaw_mulAddZ31(options: Int) extends Module
     | advance, so the circuitry can be minimized at the expense of speed.
 *** ANY WAY TO TELL THIS TO THE TOOLS?
     *------------------------------------------------------------------------*/
-    val sExpP1_PC = sExp_PC + SInt(1)
-    val sigTP1_E = sigT_E +& UInt(1)
+    val sExpP1_PC = sExp_PC + 1.S
+    val sigTP1_E = sigT_E +& 1.U
 
     /*------------------------------------------------------------------------
     *------------------------------------------------------------------------*/
@@ -705,10 +706,10 @@ class DivSqrtRecF64ToRaw_mulAddZ31(options: Int) extends Module
     io.rawOut.isZero := isZero_PC
     io.rawOut.sign := sign_PC
     io.rawOut.sExp :=
-        Mux(! sqrtOp_PC &&   E_E_div, sExp_PC,                    SInt(0)) |
-        Mux(! sqrtOp_PC && ! E_E_div, sExpP1_PC,                  SInt(0)) |
-        Mux(  sqrtOp_PC,              (sExp_PC>>1) +& SInt(1024), SInt(0))
-    io.rawOut.sig := Cat(Mux(trueLtX_E1, sigT_E, sigTP1_E), ! trueEqX_E1)
+        Mux(! sqrtOp_PC &&   E_E_div, sExp_PC,                    0.S) |
+        Mux(! sqrtOp_PC && ! E_E_div, sExpP1_PC,                  0.S) |
+        Mux(  sqrtOp_PC,              (sExp_PC>>1) +& 1024.S, 0.S)
+    io.rawOut.sig := Mux(trueLtX_E1, sigT_E, sigTP1_E) ## ! trueEqX_E1
 
 }
 
@@ -720,34 +721,34 @@ class DivSqrtRecF64_mulAddZ31(options: Int) extends Module
     val io = IO(new Bundle {
         /*--------------------------------------------------------------------
         *--------------------------------------------------------------------*/
-        val inReady_div    = Bool(OUTPUT)
-        val inReady_sqrt   = Bool(OUTPUT)
-        val inValid        = Bool(INPUT)
-        val sqrtOp         = Bool(INPUT)
-        val a              = Bits(INPUT, 65)
-        val b              = Bits(INPUT, 65)
-        val roundingMode   = UInt(INPUT, 3)
-        val detectTininess = UInt(INPUT, 1)
+        val inReady_div    = Output(Bool())
+        val inReady_sqrt   = Output(Bool())
+        val inValid        = Input(Bool())
+        val sqrtOp         = Input(Bool())
+        val a              = Input(Bits(65.W))
+        val b              = Input(Bits(65.W))
+        val roundingMode   = Input(UInt(3.W))
+        val detectTininess = Input(UInt(1.W))
         /*--------------------------------------------------------------------
         *--------------------------------------------------------------------*/
-        val usingMulAdd    = Bits(OUTPUT, 4)
-        val latchMulAddA_0 = Bool(OUTPUT)
-        val mulAddA_0      = UInt(OUTPUT, 54)
-        val latchMulAddB_0 = Bool(OUTPUT)
-        val mulAddB_0      = UInt(OUTPUT, 54)
-        val mulAddC_2      = UInt(OUTPUT, 105)
-        val mulAddResult_3 = UInt(INPUT, 105)
+        val usingMulAdd    = Output(Bits(4.W))
+        val latchMulAddA_0 = Output(Bool())
+        val mulAddA_0      = Output(UInt(54.W))
+        val latchMulAddB_0 = Output(Bool())
+        val mulAddB_0      = Output(UInt(54.W))
+        val mulAddC_2      = Output(UInt(105.W))
+        val mulAddResult_3 = Input(UInt(105.W))
         /*--------------------------------------------------------------------
         *--------------------------------------------------------------------*/
-        val outValid_div   = Bool(OUTPUT)
-        val outValid_sqrt  = Bool(OUTPUT)
-        val out            = Bits(OUTPUT, 65)
-        val exceptionFlags = Bits(OUTPUT, 5)
+        val outValid_div   = Output(Bool())
+        val outValid_sqrt  = Output(Bool())
+        val out            = Output(Bits(65.W))
+        val exceptionFlags = Output(Bits(5.W))
     })
 
     //------------------------------------------------------------------------
     //------------------------------------------------------------------------
-    val divSqrtRecF64ToRaw = Module(new DivSqrtRecF64ToRaw_mulAddZ31(options))
+    val divSqrtRecF64ToRaw = Module(new DivSqrtRecF64ToRaw_mulAddZ31)
 
     io.inReady_div  := divSqrtRecF64ToRaw.io.inReady_div
     io.inReady_sqrt := divSqrtRecF64ToRaw.io.inReady_sqrt

--- a/src/main/scala/DivSqrtRecF64_mulAddZ31.scala
+++ b/src/main/scala/DivSqrtRecF64_mulAddZ31.scala
@@ -83,12 +83,12 @@ class DivSqrtRecF64ToRaw_mulAddZ31 extends Module
 
     /*------------------------------------------------------------------------
     *------------------------------------------------------------------------*/
-    val cycleNum_A      = Reg(0.U(3.W))
-    val cycleNum_B      = Reg(0.U(4.W))
-    val cycleNum_C      = Reg(0.U(3.W))
-    val cycleNum_E      = Reg(0.U(3.W))
+    val cycleNum_A      = RegInit(0.U(3.W))
+    val cycleNum_B      = RegInit(0.U(4.W))
+    val cycleNum_C      = RegInit(0.U(3.W))
+    val cycleNum_E      = RegInit(0.U(3.W))
 
-    val valid_PA        = Reg(false.B)
+    val valid_PA        = RegInit(false.B)
     val sqrtOp_PA       = Reg(Bool())
     val majorExc_PA     = Reg(Bool())
 //*** REDUCE 3 BITS TO 2-BIT CODE:
@@ -623,7 +623,7 @@ class DivSqrtRecF64ToRaw_mulAddZ31 extends Module
         Mux(cyc_E3_sqrt,
             (Mux(sExp_PC(0),
                  sigB_PC(0)<<1,
-                 sigB_PC(1) ^ sigB_PC(0) ## sigB_PC(0)
+                 (sigB_PC(1) ^ sigB_PC(0)) ## sigB_PC(0)
              ) ^ ((~ sigT_E(0))<<1)
             )<<54,
             0.U

--- a/src/main/scala/DivSqrtRecFN_small.scala
+++ b/src/main/scala/DivSqrtRecFN_small.scala
@@ -187,7 +187,7 @@ package hardfloat
 
 import chisel3._
 import chisel3.util._
-import hardfloat.consts._
+import consts._
 
 /*----------------------------------------------------------------------------
 | Computes a division or square root for floating-point in recoded form.

--- a/src/main/scala/INToRecFN.scala
+++ b/src/main/scala/INToRecFN.scala
@@ -47,7 +47,7 @@ class INToRecFN(intWidth: Int, expWidth: Int, sigWidth: Int) extends RawModule
         val in = Input(Bits(intWidth.W))
         val roundingMode   = Input(UInt(3.W))
         val detectTininess = Input(UInt(1.W))
-        val out = Input(Bits((expWidth + sigWidth + 1).W))
+        val out = Output(Bits((expWidth + sigWidth + 1).W))
         val exceptionFlags = Output(Bits(5.W))
     })
 

--- a/src/main/scala/INToRecFN.scala
+++ b/src/main/scala/INToRecFN.scala
@@ -37,18 +37,18 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 package hardfloat
 
-import Chisel._
+import chisel3._
 import consts._
 
-class INToRecFN(intWidth: Int, expWidth: Int, sigWidth: Int) extends chisel3.RawModule
+class INToRecFN(intWidth: Int, expWidth: Int, sigWidth: Int) extends RawModule
 {
     val io = IO(new Bundle {
-        val signedIn = Bool(INPUT)
-        val in = Bits(INPUT, intWidth)
-        val roundingMode   = UInt(INPUT, 3)
-        val detectTininess = UInt(INPUT, 1)
-        val out = Bits(OUTPUT, expWidth + sigWidth + 1)
-        val exceptionFlags = Bits(OUTPUT, 5)
+        val signedIn = Input(Bool())
+        val in = Input(Bits(intWidth.W))
+        val roundingMode   = Input(UInt(3.W))
+        val detectTininess = Input(UInt(1.W))
+        val out = Input(Bits((expWidth + sigWidth + 1).W))
+        val exceptionFlags = Output(Bits(5.W))
     })
 
     //------------------------------------------------------------------------
@@ -64,8 +64,8 @@ class INToRecFN(intWidth: Int, expWidth: Int, sigWidth: Int) extends chisel3.Raw
                     sigWidth,
                     flRoundOpt_sigMSBitAlwaysZero | flRoundOpt_neverUnderflows
                 ))
-    roundAnyRawFNToRecFN.io.invalidExc     := Bool(false)
-    roundAnyRawFNToRecFN.io.infiniteExc    := Bool(false)
+    roundAnyRawFNToRecFN.io.invalidExc     := false.B
+    roundAnyRawFNToRecFN.io.infiniteExc    := false.B
     roundAnyRawFNToRecFN.io.in             := intAsRawFloat
     roundAnyRawFNToRecFN.io.roundingMode   := io.roundingMode
     roundAnyRawFNToRecFN.io.detectTininess := io.detectTininess

--- a/src/main/scala/MulAddRecFN.scala
+++ b/src/main/scala/MulAddRecFN.scala
@@ -37,7 +37,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 package hardfloat
 
-import Chisel._
+import chisel3._
+import chisel3.util._
 import consts._
 
 //----------------------------------------------------------------------------
@@ -56,28 +57,28 @@ class MulAddRecFN_interIo(expWidth: Int, sigWidth: Int) extends Bundle
     val isNaNC          = Bool()
     val isInfC          = Bool()
     val isZeroC         = Bool()
-    val sExpSum         = SInt(width = expWidth + 2)
+    val sExpSum         = SInt((expWidth + 2).W)
     val doSubMags       = Bool()
     val CIsDominant     = Bool()
-    val CDom_CAlignDist = UInt(width = log2Up(sigWidth + 1))
-    val highAlignedSigC = UInt(width = sigWidth + 2)
-    val bit0AlignedSigC = UInt(width = 1)
+    val CDom_CAlignDist = UInt(log2Ceil(sigWidth + 1).W)
+    val highAlignedSigC = UInt((sigWidth + 2).W)
+    val bit0AlignedSigC = UInt(1.W)
 
 }
 
 //----------------------------------------------------------------------------
 //----------------------------------------------------------------------------
-class MulAddRecFNToRaw_preMul(expWidth: Int, sigWidth: Int) extends chisel3.RawModule
+class MulAddRecFNToRaw_preMul(expWidth: Int, sigWidth: Int) extends RawModule
 {
     val io = IO(new Bundle {
-        val op = Bits(INPUT, 2)
-        val a = Bits(INPUT, expWidth + sigWidth + 1)
-        val b = Bits(INPUT, expWidth + sigWidth + 1)
-        val c = Bits(INPUT, expWidth + sigWidth + 1)
-        val mulAddA = UInt(OUTPUT, sigWidth)
-        val mulAddB = UInt(OUTPUT, sigWidth)
-        val mulAddC = UInt(OUTPUT, sigWidth * 2)
-        val toPostMul = new MulAddRecFN_interIo(expWidth, sigWidth).asOutput
+        val op = Input(Bits(2.W))
+        val a = Input(Bits((expWidth + sigWidth + 1).W))
+        val b = Input(Bits((expWidth + sigWidth + 1).W))
+        val c = Input(Bits((expWidth + sigWidth + 1).W))
+        val mulAddA = Output(UInt(sigWidth.W))
+        val mulAddB = Output(UInt(sigWidth.W))
+        val mulAddC = Output(UInt((sigWidth * 2).W))
+        val toPostMul = Output(new MulAddRecFN_interIo(expWidth, sigWidth))
     })
 
     //------------------------------------------------------------------------
@@ -95,7 +96,7 @@ class MulAddRecFNToRaw_preMul(expWidth: Int, sigWidth: Int) extends chisel3.RawM
     val signProd = rawA.sign ^ rawB.sign ^ io.op(1)
 //*** REVIEW THE BIAS FOR 'sExpAlignedProd':
     val sExpAlignedProd =
-        rawA.sExp +& rawB.sExp + SInt(-(BigInt(1)<<expWidth) + sigWidth + 3)
+        rawA.sExp +& rawB.sExp + (-(BigInt(1)<<expWidth) + sigWidth + 3).S
 
     val doSubMags = signProd ^ rawC.sign ^ io.op(0)
 
@@ -103,21 +104,19 @@ class MulAddRecFNToRaw_preMul(expWidth: Int, sigWidth: Int) extends chisel3.RawM
     //------------------------------------------------------------------------
     val sNatCAlignDist = sExpAlignedProd - rawC.sExp
     val posNatCAlignDist = sNatCAlignDist(expWidth + 1, 0)
-    val isMinCAlign = rawA.isZero || rawB.isZero || (sNatCAlignDist < SInt(0))
+    val isMinCAlign = rawA.isZero || rawB.isZero || (sNatCAlignDist < 0.S)
     val CIsDominant =
-        ! rawC.isZero && (isMinCAlign || (posNatCAlignDist <= UInt(sigWidth)))
+        ! rawC.isZero && (isMinCAlign || (posNatCAlignDist <= sigWidth.U))
     val CAlignDist =
         Mux(isMinCAlign,
-            UInt(0),
-            Mux(posNatCAlignDist < UInt(sigSumWidth - 1),
-                posNatCAlignDist(log2Up(sigSumWidth) - 1, 0),
-                UInt(sigSumWidth - 1)
+            0.U,
+            Mux(posNatCAlignDist < (sigSumWidth - 1).U,
+                posNatCAlignDist(log2Ceil(sigSumWidth) - 1, 0),
+                (sigSumWidth - 1).U
             )
         )
     val mainAlignedSigC =
-        Cat(Mux(doSubMags, ~rawC.sig, rawC.sig),
-            Fill(sigSumWidth - sigWidth + 2, doSubMags)
-        ).asSInt>>CAlignDist
+        Mux(doSubMags, ~rawC.sig, rawC.sig) ## Fill(sigSumWidth - sigWidth + 2, doSubMags).asSInt>>CAlignDist
     val reduced4CExtra =
         (orReduceBy4(rawC.sig<<((sigSumWidth - sigWidth - 1) & 3)) &
              lowMask(
@@ -155,10 +154,10 @@ class MulAddRecFNToRaw_preMul(expWidth: Int, sigWidth: Int) extends chisel3.RawM
     io.toPostMul.isInfC    := rawC.isInf
     io.toPostMul.isZeroC   := rawC.isZero
     io.toPostMul.sExpSum   :=
-        Mux(CIsDominant, rawC.sExp, sExpAlignedProd - SInt(sigWidth))
+        Mux(CIsDominant, rawC.sExp, sExpAlignedProd - sigWidth.S)
     io.toPostMul.doSubMags := doSubMags
     io.toPostMul.CIsDominant := CIsDominant
-    io.toPostMul.CDom_CAlignDist := CAlignDist(log2Up(sigWidth + 1) - 1, 0)
+    io.toPostMul.CDom_CAlignDist := CAlignDist(log2Ceil(sigWidth + 1) - 1, 0)
     io.toPostMul.highAlignedSigC :=
         alignedSigC(sigSumWidth - 1, sigWidth * 2 + 1)
     io.toPostMul.bit0AlignedSigC := alignedSigC(0)
@@ -166,14 +165,14 @@ class MulAddRecFNToRaw_preMul(expWidth: Int, sigWidth: Int) extends chisel3.RawM
 
 //----------------------------------------------------------------------------
 //----------------------------------------------------------------------------
-class MulAddRecFNToRaw_postMul(expWidth: Int, sigWidth: Int) extends chisel3.RawModule
+class MulAddRecFNToRaw_postMul(expWidth: Int, sigWidth: Int) extends RawModule
 {
     val io = IO(new Bundle {
-        val fromPreMul = new MulAddRecFN_interIo(expWidth, sigWidth).asInput
-        val mulAddResult = UInt(INPUT, sigWidth * 2 + 1)
-        val roundingMode = UInt(INPUT, 3)
-        val invalidExc  = Bool(OUTPUT)
-        val rawOut = new RawFloat(expWidth, sigWidth + 2).asOutput
+        val fromPreMul = Input(new MulAddRecFN_interIo(expWidth, sigWidth))
+        val mulAddResult = Input(UInt((sigWidth * 2 + 1).W))
+        val roundingMode = Input(UInt(3.W))
+        val invalidExc  = Output(Bool())
+        val rawOut = Output(new RawFloat(expWidth, sigWidth + 2))
     })
 
     //------------------------------------------------------------------------
@@ -189,7 +188,7 @@ class MulAddRecFNToRaw_postMul(expWidth: Int, sigWidth: Int) extends chisel3.Raw
     val opSignC = io.fromPreMul.signProd ^ io.fromPreMul.doSubMags
     val sigSum =
         Cat(Mux(io.mulAddResult(sigWidth * 2),
-                io.fromPreMul.highAlignedSigC + UInt(1),
+                io.fromPreMul.highAlignedSigC + 1.U,
                 io.fromPreMul.highAlignedSigC
                ),
             io.mulAddResult(sigWidth * 2 - 1, 0),
@@ -203,11 +202,11 @@ class MulAddRecFNToRaw_postMul(expWidth: Int, sigWidth: Int) extends chisel3.Raw
     val CDom_absSigSum =
         Mux(io.fromPreMul.doSubMags,
             ~sigSum(sigSumWidth - 1, sigWidth + 1),
-            Cat(UInt(0, 1),
+            0.U(1.W) ##
 //*** IF GAP IS REDUCED TO 1 BIT, MUST REDUCE THIS COMPONENT TO 1 BIT TOO:
-                io.fromPreMul.highAlignedSigC(sigWidth + 1, sigWidth),
+                io.fromPreMul.highAlignedSigC(sigWidth + 1, sigWidth) ##
                 sigSum(sigSumWidth - 3, sigWidth + 2)
-            )
+
         )
     val CDom_absSigSumExtra =
         Mux(io.fromPreMul.doSubMags,
@@ -237,7 +236,7 @@ class MulAddRecFNToRaw_postMul(expWidth: Int, sigWidth: Int) extends chisel3.Raw
     val notCDom_reduced2AbsSigSum = orReduceBy2(notCDom_absSigSum)
     val notCDom_normDistReduced2 = countLeadingZeros(notCDom_reduced2AbsSigSum)
     val notCDom_nearNormDist = notCDom_normDistReduced2<<1
-    val notCDom_sExp = io.fromPreMul.sExpSum - notCDom_nearNormDist.zext
+    val notCDom_sExp = io.fromPreMul.sExpSum - notCDom_nearNormDist.asUInt().zext
     val notCDom_mainSig =
         (notCDom_absSigSum<<notCDom_nearNormDist)(
             sigWidth * 2 + 3, sigWidth - 1)
@@ -251,7 +250,7 @@ class MulAddRecFNToRaw_postMul(expWidth: Int, sigWidth: Int) extends chisel3.Raw
             notCDom_mainSig(2, 0).orR || notCDom_reduced4SigExtra
         )
     val notCDom_completeCancellation =
-        (notCDom_sig(sigWidth + 2, sigWidth + 1) === UInt(0))
+        (notCDom_sig(sigWidth + 2, sigWidth + 1) === 0.U)
     val notCDom_sign =
         Mux(notCDom_completeCancellation,
             roundingMode_min,
@@ -296,17 +295,17 @@ class MulAddRecFNToRaw_postMul(expWidth: Int, sigWidth: Int) extends chisel3.Raw
 //----------------------------------------------------------------------------
 //----------------------------------------------------------------------------
 
-class MulAddRecFN(expWidth: Int, sigWidth: Int) extends chisel3.RawModule
+class MulAddRecFN(expWidth: Int, sigWidth: Int) extends RawModule
 {
     val io = IO(new Bundle {
-        val op = Bits(INPUT, 2)
-        val a = Bits(INPUT, expWidth + sigWidth + 1)
-        val b = Bits(INPUT, expWidth + sigWidth + 1)
-        val c = Bits(INPUT, expWidth + sigWidth + 1)
-        val roundingMode   = UInt(INPUT, 3)
-        val detectTininess = UInt(INPUT, 1)
-        val out = Bits(OUTPUT, expWidth + sigWidth + 1)
-        val exceptionFlags = Bits(OUTPUT, 5)
+        val op = Input(Bits(2.W))
+        val a = Input(Bits((expWidth + sigWidth + 1).W))
+        val b = Input(Bits((expWidth + sigWidth + 1).W))
+        val c = Input(Bits((expWidth + sigWidth + 1).W))
+        val roundingMode   = Input(UInt(3.W))
+        val detectTininess = Input(UInt(1.W))
+        val out = Output(Bits((expWidth + sigWidth + 1).W))
+        val exceptionFlags = Output(Bits(5.W))
     })
 
     //------------------------------------------------------------------------
@@ -336,7 +335,7 @@ class MulAddRecFN(expWidth: Int, sigWidth: Int) extends chisel3.RawModule
     val roundRawFNToRecFN =
         Module(new RoundRawFNToRecFN(expWidth, sigWidth, 0))
     roundRawFNToRecFN.io.invalidExc   := mulAddRecFNToRaw_postMul.io.invalidExc
-    roundRawFNToRecFN.io.infiniteExc  := Bool(false)
+    roundRawFNToRecFN.io.infiniteExc  := false.B
     roundRawFNToRecFN.io.in           := mulAddRecFNToRaw_postMul.io.rawOut
     roundRawFNToRecFN.io.roundingMode := io.roundingMode
     roundRawFNToRecFN.io.detectTininess := io.detectTininess

--- a/src/main/scala/MulAddRecFN.scala
+++ b/src/main/scala/MulAddRecFN.scala
@@ -116,7 +116,7 @@ class MulAddRecFNToRaw_preMul(expWidth: Int, sigWidth: Int) extends RawModule
             )
         )
     val mainAlignedSigC =
-        Mux(doSubMags, ~rawC.sig, rawC.sig) ## Fill(sigSumWidth - sigWidth + 2, doSubMags).asSInt>>CAlignDist
+        (Mux(doSubMags, ~rawC.sig, rawC.sig) ## Fill(sigSumWidth - sigWidth + 2, doSubMags)).asSInt>>CAlignDist
     val reduced4CExtra =
         (orReduceBy4(rawC.sig<<((sigSumWidth - sigWidth - 1) & 3)) &
              lowMask(

--- a/src/main/scala/RecFNToRecFN.scala
+++ b/src/main/scala/RecFNToRecFN.scala
@@ -37,7 +37,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 package hardfloat
 
-import Chisel._
+import chisel3._
 import consts._
 
 class
@@ -46,11 +46,11 @@ class
     extends chisel3.RawModule
 {
     val io = IO(new Bundle {
-        val in = Bits(INPUT, inExpWidth + inSigWidth + 1)
-        val roundingMode   = UInt(INPUT, 3)
-        val detectTininess = UInt(INPUT, 1)
-        val out = Bits(OUTPUT, outExpWidth + outSigWidth + 1)
-        val exceptionFlags = Bits(OUTPUT, 5)
+        val in = Input(Bits((inExpWidth + inSigWidth + 1).W))
+        val roundingMode   = Input(UInt(3.W))
+        val detectTininess = Input(UInt(1.W))
+        val out = Output(Bits((outExpWidth + outSigWidth + 1).W))
+        val exceptionFlags = Output(Bits(5.W))
     })
 
     //------------------------------------------------------------------------
@@ -62,7 +62,7 @@ class
         //--------------------------------------------------------------------
         //--------------------------------------------------------------------
         io.out            := io.in<<(outSigWidth - inSigWidth)
-        io.exceptionFlags := Cat(isSigNaNRawFloat(rawIn), Bits(0, 4))
+        io.exceptionFlags := isSigNaNRawFloat(rawIn) ## 0.U(4.W)
 
     } else {
 
@@ -78,7 +78,7 @@ class
                         flRoundOpt_sigMSBitAlwaysZero
                     ))
         roundAnyRawFNToRecFN.io.invalidExc     := isSigNaNRawFloat(rawIn)
-        roundAnyRawFNToRecFN.io.infiniteExc    := Bool(false)
+        roundAnyRawFNToRecFN.io.infiniteExc    := false.B
         roundAnyRawFNToRecFN.io.in             := rawIn
         roundAnyRawFNToRecFN.io.roundingMode   := io.roundingMode
         roundAnyRawFNToRecFN.io.detectTininess := io.detectTininess

--- a/src/main/scala/RoundAnyRawFNToRecFN.scala
+++ b/src/main/scala/RoundAnyRawFNToRecFN.scala
@@ -151,11 +151,11 @@ class
             if (neverUnderflows)
                 0.U(outSigWidth.W) ## doShiftSigDown1 ## 3.U(2.W)
             else
-                lowMask(
+                (lowMask(
                         sAdjustedExp(outExpWidth, 0),
                         outMinNormExp - outSigWidth - 1,
                         outMinNormExp
-                    ) | doShiftSigDown1 ##
+                    ) | doShiftSigDown1) ##
                   3.U(2.W)
 
         val shiftedRoundMask = 0.U(1.W) ## roundMask>>1

--- a/src/main/scala/RoundAnyRawFNToRecFN.scala
+++ b/src/main/scala/RoundAnyRawFNToRecFN.scala
@@ -37,7 +37,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 package hardfloat
 
-import Chisel._
+import chisel3._
+import chisel3.util.Fill
 import consts._
 
 //----------------------------------------------------------------------------
@@ -51,17 +52,17 @@ class
         outSigWidth: Int,
         options: Int
     )
-    extends chisel3.RawModule
+    extends RawModule
 {
     val io = IO(new Bundle {
-        val invalidExc  = Bool(INPUT)   // overrides 'infiniteExc' and 'in'
-        val infiniteExc = Bool(INPUT)   // overrides 'in' except for 'in.sign'
-        val in = new RawFloat(inExpWidth, inSigWidth).asInput
+        val invalidExc  = Input(Bool())   // overrides 'infiniteExc' and 'in'
+        val infiniteExc = Input(Bool())   // overrides 'in' except for 'in.sign'
+        val in = Input(new RawFloat(inExpWidth, inSigWidth))
                                         // (allowed exponent range has limits)
-        val roundingMode   = UInt(INPUT, 3)
-        val detectTininess = UInt(INPUT, 1)
-        val out = Bits(OUTPUT, outExpWidth + outSigWidth + 1)
-        val exceptionFlags = Bits(OUTPUT, 5)
+        val roundingMode   = Input(UInt(3.W))
+        val detectTininess = Input(UInt(1.W))
+        val out = Output(Bits((outExpWidth + outSigWidth + 1).W))
+        val exceptionFlags = Output(Bits(5.W))
     })
 
     //------------------------------------------------------------------------
@@ -100,25 +101,25 @@ class
     val sAdjustedExp =
         if (inExpWidth < outExpWidth)
             (io.in.sExp +&
-                 SInt((BigInt(1)<<outExpWidth) - (BigInt(1)<<inExpWidth))
+                 ((BigInt(1)<<outExpWidth) - (BigInt(1)<<inExpWidth)).S
             )(outExpWidth, 0).zext
         else if (inExpWidth == outExpWidth)
             io.in.sExp
         else
             io.in.sExp +&
-                SInt((BigInt(1)<<outExpWidth) - (BigInt(1)<<inExpWidth))
+                ((BigInt(1)<<outExpWidth) - (BigInt(1)<<inExpWidth)).S
     val adjustedSig =
         if (inSigWidth <= outSigWidth + 2)
             io.in.sig<<(outSigWidth - inSigWidth + 2)
         else
-            Cat(io.in.sig(inSigWidth, inSigWidth - outSigWidth - 1),
+            (io.in.sig(inSigWidth, inSigWidth - outSigWidth - 1) ##
                 io.in.sig(inSigWidth - outSigWidth - 2, 0).orR
             )
     val doShiftSigDown1 =
-        if (sigMSBitAlwaysZero) Bool(false) else adjustedSig(outSigWidth + 2)
+        if (sigMSBitAlwaysZero) false.B else adjustedSig(outSigWidth + 2)
 
-    val common_expOut   = Wire(UInt(width = outExpWidth + 1))
-    val common_fractOut = Wire(UInt(width = outSigWidth - 1))
+    val common_expOut   = Wire(UInt((outExpWidth + 1).W))
+    val common_fractOut = Wire(UInt((outSigWidth - 1).W))
     val common_overflow       = Wire(Bool())
     val common_totalUnderflow = Wire(Bool())
     val common_underflow      = Wire(Bool())
@@ -137,10 +138,10 @@ class
                 adjustedSig(outSigWidth + 1, 3),
                 adjustedSig(outSigWidth, 2)
             )
-        common_overflow       := Bool(false)
-        common_totalUnderflow := Bool(false)
-        common_underflow      := Bool(false)
-        common_inexact        := Bool(false)
+        common_overflow       := false.B
+        common_totalUnderflow := false.B
+        common_underflow      := false.B
+        common_inexact        := false.B
 
     } else {
 
@@ -148,16 +149,16 @@ class
         //--------------------------------------------------------------------
         val roundMask =
             if (neverUnderflows)
-                Cat(UInt(0, outSigWidth), doShiftSigDown1, UInt(3, 2))
+                0.U(outSigWidth.W) ## doShiftSigDown1 ## 3.U(2.W)
             else
-                Cat(lowMask(
+                lowMask(
                         sAdjustedExp(outExpWidth, 0),
                         outMinNormExp - outSigWidth - 1,
                         outMinNormExp
-                    ) | doShiftSigDown1,
-                    UInt(3, 2)
-                )
-        val shiftedRoundMask = Cat(UInt(0, 1), roundMask>>1)
+                    ) | doShiftSigDown1 ##
+                  3.U(2.W)
+
+        val shiftedRoundMask = 0.U(1.W) ## roundMask>>1
         val roundPosMask = ~shiftedRoundMask & roundMask
         val roundPosBit = (adjustedSig & roundPosMask).orR
         val anyRoundExtra = (adjustedSig & shiftedRoundMask).orR
@@ -167,20 +168,20 @@ class
             ((roundingMode_near_even || roundingMode_near_maxMag) &&
                  roundPosBit) ||
                 (roundMagUp && anyRound)
-        val roundedSig =
+        val roundedSig: Bits =
             Mux(roundIncr,
-                (((adjustedSig | roundMask)>>2) +& UInt(1)) &
+                (((adjustedSig | roundMask)>>2) +& 1.U) &
                     ~Mux(roundingMode_near_even && roundPosBit &&
                              ! anyRoundExtra,
                          roundMask>>1,
-                         UInt(0, outSigWidth + 2)
+                         0.U((outSigWidth + 2).W)
                      ),
                 (adjustedSig & ~roundMask)>>2 |
-                    Mux(roundingMode_odd && anyRound, roundPosMask>>1, UInt(0))
+                    Mux(roundingMode_odd && anyRound, roundPosMask>>1, 0.U)
             )
 //*** IF SIG WIDTH IS VERY NARROW, NEED TO ACCOUNT FOR ROUND-EVEN ZEROING
 //***  M.S. BIT OF SUBNORMAL SIG?
-        val sRoundedExp = sAdjustedExp +& (roundedSig>>outSigWidth).zext
+        val sRoundedExp = sAdjustedExp +& (roundedSig>>outSigWidth).asUInt().zext
 
         common_expOut := sRoundedExp(outExpWidth, 0)
         common_fractOut :=
@@ -189,13 +190,13 @@ class
                 roundedSig(outSigWidth - 2, 0)
             )
         common_overflow :=
-            (if (neverOverflows) Bool(false) else
+            (if (neverOverflows) false.B else
 //*** REWRITE BASED ON BEFORE-ROUNDING EXPONENT?:
-                 (sRoundedExp>>(outExpWidth - 1) >= SInt(3)))
+                 (sRoundedExp>>(outExpWidth - 1) >= 3.S))
         common_totalUnderflow :=
-            (if (neverUnderflows) Bool(false) else
+            (if (neverUnderflows) false.B else
 //*** WOULD BE GOOD ENOUGH TO USE EXPONENT BEFORE ROUNDING?:
-                 (sRoundedExp < SInt(outMinNonzeroExp)))
+                 (sRoundedExp < outMinNonzeroExp.S))
 
         val unboundedRange_roundPosBit =
             Mux(doShiftSigDown1, adjustedSig(2), adjustedSig(1))
@@ -211,11 +212,11 @@ class
                 roundedSig(outSigWidth)
             )
         common_underflow :=
-            (if (neverUnderflows) Bool(false) else
+            (if (neverUnderflows) false.B else
                  common_totalUnderflow ||
 //*** IF SIG WIDTH IS VERY NARROW, NEED TO ACCOUNT FOR ROUND-EVEN ZEROING
 //***  M.S. BIT OF SUBNORMAL SIG?
-                     (anyRound && (sAdjustedExp>>outExpWidth <= SInt(0)) &&
+                     (anyRound && ((sAdjustedExp>>outExpWidth) <= 0.S) &&
                           Mux(doShiftSigDown1, roundMask(3), roundMask(2)) &&
                           ! ((io.detectTininess === tininess_afterRounding) &&
                                  ! Mux(doShiftSigDown1,
@@ -245,45 +246,45 @@ class
     val notNaN_isInfOut =
         notNaN_isSpecialInfOut || (overflow && overflow_roundMagUp)
 
-    val signOut = Mux(isNaNOut, Bool(false), io.in.sign)
+    val signOut = Mux(isNaNOut, false.B, io.in.sign)
     val expOut =
         (common_expOut &
              ~Mux(io.in.isZero || common_totalUnderflow,
-                  UInt(BigInt(7)<<(outExpWidth - 2), outExpWidth + 1),
-                  UInt(0)
+               (BigInt(7)<<(outExpWidth - 2)).U((outExpWidth + 1).W),
+               0.U
               ) &
              ~Mux(pegMinNonzeroMagOut,
-                  ~UInt(outMinNonzeroExp, outExpWidth + 1),
-                  UInt(0)
+                  ~outMinNonzeroExp.U((outExpWidth + 1).W),
+               0.U
               ) &
              ~Mux(pegMaxFiniteMagOut,
-                  UInt(BigInt(1)<<(outExpWidth - 1), outExpWidth + 1),
-                  UInt(0)
+               (BigInt(1)<<(outExpWidth - 1)).U((outExpWidth + 1).W),
+               0.U
               ) &
              ~Mux(notNaN_isInfOut,
-                  UInt(BigInt(1)<<(outExpWidth - 2), outExpWidth + 1),
-                  UInt(0)
+               (BigInt(1)<<(outExpWidth - 2)).U((outExpWidth + 1).W),
+               0.U
               )) |
             Mux(pegMinNonzeroMagOut,
-                UInt(outMinNonzeroExp, outExpWidth + 1),
-                UInt(0)
+              outMinNonzeroExp.U((outExpWidth + 1).W),
+              0.U
             ) |
             Mux(pegMaxFiniteMagOut,
-                UInt(outMaxFiniteExp, outExpWidth + 1),
-                UInt(0)
+              outMaxFiniteExp.U((outExpWidth + 1).W),
+              0.U
             ) |
-            Mux(notNaN_isInfOut, UInt(outInfExp, outExpWidth + 1), UInt(0)) |
-            Mux(isNaNOut,        UInt(outNaNExp, outExpWidth + 1), UInt(0))
+            Mux(notNaN_isInfOut, outInfExp.U((outExpWidth + 1).W), 0.U) |
+            Mux(isNaNOut,        outNaNExp.U((outExpWidth + 1).W), 0.U)
     val fractOut =
         Mux(isNaNOut || io.in.isZero || common_totalUnderflow,
-            Mux(isNaNOut, UInt(BigInt(1)<<(outSigWidth - 2)), UInt(0)),
+            Mux(isNaNOut, (BigInt(1)<<(outSigWidth - 2)).U, 0.U),
             common_fractOut
         ) |
         Fill(outSigWidth - 1, pegMaxFiniteMagOut)
 
-    io.out := Cat(signOut, expOut, fractOut)
+    io.out := signOut ## expOut ## fractOut
     io.exceptionFlags :=
-        Cat(io.invalidExc, io.infiniteExc, overflow, underflow, inexact)
+        io.invalidExc ## io.infiniteExc ## overflow ## underflow ## inexact
 }
 
 //----------------------------------------------------------------------------
@@ -291,16 +292,16 @@ class
 
 class
     RoundRawFNToRecFN(expWidth: Int, sigWidth: Int, options: Int)
-    extends chisel3.RawModule
+    extends RawModule
 {
     val io = IO(new Bundle {
-        val invalidExc  = Bool(INPUT)   // overrides 'infiniteExc' and 'in'
-        val infiniteExc = Bool(INPUT)   // overrides 'in' except for 'in.sign'
-        val in = new RawFloat(expWidth, sigWidth + 2).asInput
-        val roundingMode   = UInt(INPUT, 3)
-        val detectTininess = UInt(INPUT, 1)
-        val out = Bits(OUTPUT, expWidth + sigWidth + 1)
-        val exceptionFlags = Bits(OUTPUT, 5)
+        val invalidExc  = Input(Bool())   // overrides 'infiniteExc' and 'in'
+        val infiniteExc = Input(Bool())   // overrides 'in' except for 'in.sign'
+        val in = Input(new RawFloat(expWidth, sigWidth + 2))
+        val roundingMode   = Input(UInt(3.W))
+        val detectTininess = Input(UInt(1.W))
+        val out = Output(Bits((expWidth + sigWidth + 1).W))
+        val exceptionFlags = Output(Bits(5.W))
     })
 
     val roundAnyRawFNToRecFN =

--- a/src/main/scala/classifyRecFN.scala
+++ b/src/main/scala/classifyRecFN.scala
@@ -37,31 +37,31 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 package hardfloat
 
-import Chisel._
+import chisel3._
 
 object classifyRecFN
 {
     def apply(expWidth: Int, sigWidth: Int, in: Bits) =
     {
-        val minNormExp = (BigInt(1)<<(expWidth - 1)) + 2
+        val minNormExp: BigInt = (BigInt(1)<<(expWidth - 1)) + 2
 
-        val rawIn = rawFloatFromRecFN(expWidth, sigWidth, in)
-        val isSigNaN = isSigNaNRawFloat(rawIn)
-        val isFiniteNonzero = ! rawIn.isNaN && ! rawIn.isInf && ! rawIn.isZero
-        val isSubnormal = (rawIn.sExp < SInt(minNormExp))
+        val rawIn: RawFloat = rawFloatFromRecFN(expWidth, sigWidth, in)
+        val isSigNaN: Bool = isSigNaNRawFloat(rawIn)
+        val isFiniteNonzero: Bool = ! rawIn.isNaN && ! rawIn.isInf && ! rawIn.isZero
+        val isSubnormal: Bool = rawIn.sExp < minNormExp.S
 
-        Cat(
-            rawIn.isNaN && ! isSigNaN,
-            isSigNaN,
-            ! rawIn.sign && rawIn.isInf,
-            ! rawIn.sign && isFiniteNonzero && ! isSubnormal,
-            ! rawIn.sign && isFiniteNonzero &&   isSubnormal,
-            ! rawIn.sign && rawIn.isZero,
-            rawIn.sign   && rawIn.isZero,
-            rawIn.sign   && isFiniteNonzero &&   isSubnormal,
-            rawIn.sign   && isFiniteNonzero && ! isSubnormal,
-            rawIn.sign   && rawIn.isInf
-        )
+
+        (rawIn.isNaN && ! isSigNaN) ##
+        isSigNaN ##
+        (! rawIn.sign && rawIn.isInf) ##
+        (! rawIn.sign && isFiniteNonzero && ! isSubnormal) ##
+        (! rawIn.sign && isFiniteNonzero &&   isSubnormal) ##
+        (! rawIn.sign && rawIn.isZero) ##
+        (rawIn.sign   && rawIn.isZero) ##
+        (rawIn.sign   && isFiniteNonzero &&   isSubnormal) ##
+        (rawIn.sign   && isFiniteNonzero && ! isSubnormal) ##
+        (rawIn.sign   && rawIn.isInf)
+
     }
 }
 

--- a/src/main/scala/common.scala
+++ b/src/main/scala/common.scala
@@ -44,12 +44,12 @@ object consts {
     | For rounding to integer values, rounding mode 'odd' rounds to minimum
     | magnitude instead, same as 'minMag'.
     *------------------------------------------------------------------------*/
-    def round_near_even   = "b000".U
-    def round_minMag      = "b001".U
-    def round_min         = "b010".U
-    def round_max         = "b011".U
-    def round_near_maxMag = "b100".U
-    def round_odd         = "b110".U
+    def round_near_even   = "b000".U(3.W)
+    def round_minMag      = "b001".U(3.W)
+    def round_min         = "b010".U(3.W)
+    def round_max         = "b011".U(3.W)
+    def round_near_maxMag = "b100".U(3.W)
+    def round_odd         = "b110".U(3.W)
     /*------------------------------------------------------------------------
     *------------------------------------------------------------------------*/
     def tininess_beforeRounding = 0.U

--- a/src/main/scala/common.scala
+++ b/src/main/scala/common.scala
@@ -37,23 +37,23 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 package hardfloat
 
-import Chisel._
+import chisel3._
 
 object consts {
     /*------------------------------------------------------------------------
     | For rounding to integer values, rounding mode 'odd' rounds to minimum
     | magnitude instead, same as 'minMag'.
     *------------------------------------------------------------------------*/
-    def round_near_even   = UInt("b000", 3)
-    def round_minMag      = UInt("b001", 3)
-    def round_min         = UInt("b010", 3)
-    def round_max         = UInt("b011", 3)
-    def round_near_maxMag = UInt("b100", 3)
-    def round_odd         = UInt("b110", 3)
+    def round_near_even   = "b000".U
+    def round_minMag      = "b001".U
+    def round_min         = "b010".U
+    def round_max         = "b011".U
+    def round_near_maxMag = "b100".U
+    def round_odd         = "b110".U
     /*------------------------------------------------------------------------
     *------------------------------------------------------------------------*/
-    def tininess_beforeRounding = UInt(0, 1)
-    def tininess_afterRounding  = UInt(1, 1)
+    def tininess_beforeRounding = 0.U
+    def tininess_afterRounding  = 1.U
     /*------------------------------------------------------------------------
     *------------------------------------------------------------------------*/
     def flRoundOpt_sigMSBitAlwaysZero  = 1
@@ -67,12 +67,12 @@ object consts {
 
 class RawFloat(val expWidth: Int, val sigWidth: Int) extends Bundle
 {
-    val isNaN  = Bool()              // overrides all other fields
-    val isInf  = Bool()              // overrides 'isZero', 'sExp', and 'sig'
-    val isZero = Bool()              // overrides 'sExp' and 'sig'
-    val sign   = Bool()
-    val sExp = SInt(width = expWidth + 2)
-    val sig  = UInt(width = sigWidth + 1)   // 2 m.s. bits cannot both be 0
+    val isNaN: Bool = Bool()              // overrides all other fields
+    val isInf: Bool = Bool()              // overrides 'isZero', 'sExp', and 'sig'
+    val isZero: Bool = Bool()              // overrides 'sExp' and 'sig'
+    val sign: Bool = Bool()
+    val sExp: SInt = SInt((expWidth + 2).W)
+    val sig: UInt = UInt((sigWidth + 1).W)   // 2 m.s. bits cannot both be 0
 
 }
 

--- a/src/main/scala/fNFromRecFN.scala
+++ b/src/main/scala/fNFromRecFN.scala
@@ -37,7 +37,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 package hardfloat
 
-import Chisel._
+import chisel3._
+import chisel3.util._
 
 object fNFromRecFN
 {
@@ -47,20 +48,20 @@ object fNFromRecFN
 
         val rawIn = rawFloatFromRecFN(expWidth, sigWidth, in)
 
-        val isSubnormal = (rawIn.sExp < SInt(minNormExp))
-        val denormShiftDist = UInt(1) - rawIn.sExp(log2Up(sigWidth - 1) - 1, 0)
+        val isSubnormal = rawIn.sExp < minNormExp.S
+        val denormShiftDist = 1.U - rawIn.sExp(log2Up(sigWidth - 1) - 1, 0)
         val denormFract = ((rawIn.sig>>1)>>denormShiftDist)(sigWidth - 2, 0)
 
         val expOut =
             Mux(isSubnormal,
-                UInt(0),
+                0.U,
                 rawIn.sExp(expWidth - 1, 0) -
-                    UInt((BigInt(1)<<(expWidth - 1)) + 1)
+                  ((BigInt(1)<<(expWidth - 1)) + 1).U
             ) | Fill(expWidth, rawIn.isNaN || rawIn.isInf)
         val fractOut =
             Mux(isSubnormal,
                 denormFract,
-                Mux(rawIn.isInf, UInt(0), rawIn.sig(sigWidth - 2, 0))
+                Mux(rawIn.isInf, 0.U, rawIn.sig(sigWidth - 2, 0))
             )
         Cat(rawIn.sign, expOut, fractOut)
     }

--- a/src/main/scala/primitives.scala
+++ b/src/main/scala/primitives.scala
@@ -37,7 +37,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 package hardfloat
 
-import Chisel._
+import chisel3._
+import chisel3.util._
 
 //----------------------------------------------------------------------------
 //----------------------------------------------------------------------------
@@ -60,21 +61,19 @@ object lowMask
                 if (mid <= bottomBound) {
                     Mux(msb,
                         lowMask(lsbs, topBound - mid, bottomBound - mid),
-                        UInt(0)
+                        0.U
                     )
                 } else {
                     Mux(msb,
-                        Cat(lowMask(lsbs, topBound - mid, 0),
-                            UInt((BigInt(1)<<(mid - bottomBound).toInt) - 1)
-                        ),
+                        lowMask(lsbs, topBound - mid, 0) ## ((BigInt(1)<<(mid - bottomBound).toInt) - 1).U,
                         lowMask(lsbs, mid, bottomBound)
                     )
                 }
             } else {
-                ~Mux(msb, UInt(0), ~lowMask(lsbs, topBound, bottomBound))
+                ~Mux(msb, 0.U, ~lowMask(lsbs, topBound, bottomBound))
             }
         } else {
-            val shift = SInt(BigInt(-1)<<numInVals.toInt)>>in
+            val shift = (BigInt(-1)<<numInVals.toInt).S>>in
             Reverse(
                 shift(
                     (numInVals - 1 - bottomBound).toInt,

--- a/src/main/scala/rawFloatFromIN.scala
+++ b/src/main/scala/rawFloatFromIN.scala
@@ -37,7 +37,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 package hardfloat
 
-import Chisel._
+import chisel3._
+import chisel3.util._
 
 object rawFloatFromIN
 {
@@ -49,18 +50,18 @@ object rawFloatFromIN
 
         val sign = signedIn && in(in.getWidth - 1)
         val absIn = Mux(sign, -in.asUInt, in.asUInt)
-        val extAbsIn = Cat(UInt(0, extIntWidth), absIn)(extIntWidth - 1, 0)
+        val extAbsIn = (0.U(extIntWidth.W) ## absIn)(extIntWidth - 1, 0)
         val adjustedNormDist = countLeadingZeros(extAbsIn)
         val sig =
             (extAbsIn<<adjustedNormDist)(
                 extIntWidth - 1, extIntWidth - in.getWidth)
 
         val out = Wire(new RawFloat(expWidth, in.getWidth))
-        out.isNaN  := Bool(false)
-        out.isInf  := Bool(false)
+        out.isNaN  := false.B
+        out.isInf  := false.B
         out.isZero := ! sig(in.getWidth - 1)
         out.sign   := sign
-        out.sExp   := Cat(UInt(2, 2), ~adjustedNormDist(expWidth - 2, 0)).zext
+        out.sExp   := (2.U(2.W) ## ~adjustedNormDist(expWidth - 2, 0)).zext
         out.sig    := sig
         out
     }

--- a/src/main/scala/rawFloatFromRecFN.scala
+++ b/src/main/scala/rawFloatFromRecFN.scala
@@ -37,7 +37,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 package hardfloat
 
-import Chisel._
+import chisel3._
+import chisel3.util._
 
 /*----------------------------------------------------------------------------
 | In the result, no more than one of 'isNaN', 'isInf', and 'isZero' will be
@@ -48,8 +49,8 @@ object rawFloatFromRecFN
     def apply(expWidth: Int, sigWidth: Int, in: Bits): RawFloat =
     {
         val exp = in(expWidth + sigWidth - 1, sigWidth - 1)
-        val isZero    = (exp(expWidth, expWidth - 2) === UInt(0))
-        val isSpecial = (exp(expWidth, expWidth - 1) === UInt(3))
+        val isZero    = exp(expWidth, expWidth - 2) === 0.U
+        val isSpecial = exp(expWidth, expWidth - 1) === 3.U
 
         val out = Wire(new RawFloat(expWidth, sigWidth))
         out.isNaN  := isSpecial &&   exp(expWidth - 2)
@@ -57,7 +58,7 @@ object rawFloatFromRecFN
         out.isZero := isZero
         out.sign   := in(expWidth + sigWidth)
         out.sExp   := exp.zext
-        out.sig    := Cat(UInt(0, 1), ! isZero, in(sigWidth - 2, 0))
+        out.sig    := 0.U(1.W) ## ! isZero ## in(sigWidth - 2, 0)
         out
     }
 }

--- a/src/main/scala/recFNFromFN.scala
+++ b/src/main/scala/recFNFromFN.scala
@@ -37,19 +37,18 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 package hardfloat
 
-import Chisel._
+import chisel3._
 
 object recFNFromFN
 {
     def apply(expWidth: Int, sigWidth: Int, in: Bits) =
     {
         val rawIn = rawFloatFromFN(expWidth, sigWidth, in)
-        Cat(rawIn.sign,
-            Mux(rawIn.isZero, Bits(0, 3), rawIn.sExp(expWidth, expWidth - 2)) |
-                Mux(rawIn.isNaN, UInt(1), UInt(0)),
-            rawIn.sExp(expWidth - 3, 0),
+        rawIn.sign ##
+            Mux(rawIn.isZero, 0.U(3.W), rawIn.sExp(expWidth, expWidth - 2)) |
+                Mux(rawIn.isNaN, 1.U, 0.U) ##
+            rawIn.sExp(expWidth - 3, 0) ##
             rawIn.sig(sigWidth - 2, 0)
-        )
     }
 }
 

--- a/src/main/scala/recFNFromFN.scala
+++ b/src/main/scala/recFNFromFN.scala
@@ -45,8 +45,8 @@ object recFNFromFN
     {
         val rawIn = rawFloatFromFN(expWidth, sigWidth, in)
         rawIn.sign ##
-            Mux(rawIn.isZero, 0.U(3.W), rawIn.sExp(expWidth, expWidth - 2)) |
-                Mux(rawIn.isNaN, 1.U, 0.U) ##
+          (Mux(rawIn.isZero, 0.U(3.W), rawIn.sExp(expWidth, expWidth - 2)) |
+                Mux(rawIn.isNaN, 1.U, 0.U)) ##
             rawIn.sExp(expWidth - 3, 0) ##
             rawIn.sig(sigWidth - 2, 0)
     }

--- a/src/main/scala/resizeRawFloat.scala
+++ b/src/main/scala/resizeRawFloat.scala
@@ -37,7 +37,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 package hardfloat
 
-import Chisel._
+import chisel3._
+import chisel3.util.Fill
 
 //----------------------------------------------------------------------------
 //----------------------------------------------------------------------------
@@ -47,7 +48,7 @@ object resizeRawFloat
     def apply(expWidth: Int, sigWidth: Int, in: RawFloat): RawFloat =
     {
         val sAdjustedExp =
-            in.sExp +& SInt((BigInt(1)<<expWidth) - (BigInt(1)<<in.expWidth))
+            in.sExp +& ((BigInt(1)<<expWidth) - (BigInt(1)<<in.expWidth)).S
 
         val out = Wire(new RawFloat(expWidth, sigWidth))
         out.sign   := in.sign
@@ -58,9 +59,9 @@ object resizeRawFloat
             (if (in.expWidth <= expWidth)
                  sAdjustedExp
              else
-                 Cat((sAdjustedExp < SInt(0)),
+                 ((sAdjustedExp < 0.S)##
                      Mux(sAdjustedExp(in.expWidth + 1, expWidth + 1).orR,
-                         Cat(Fill(expWidth - 1, UInt(1, 1)), UInt(0, 2)),
+                         Fill(expWidth - 1, 1.U(1.W)) ## 0.U(2.W),
                          sAdjustedExp(expWidth, 0)
                      )
                  ).asSInt)
@@ -68,9 +69,9 @@ object resizeRawFloat
             (if (in.sigWidth <= sigWidth)
                  in.sig<<(sigWidth - in.sigWidth)
              else
-                 Cat(in.sig(in.sigWidth + 2, in.sigWidth - sigWidth + 1),
+                 in.sig(in.sigWidth + 2, in.sigWidth - sigWidth + 1) ##
                      in.sig(in.sigWidth - sigWidth, 0).orR
-                 ))
+                 )
         out
     }
 }

--- a/src/test/scala/ValExec_AddRecFN.scala
+++ b/src/test/scala/ValExec_AddRecFN.scala
@@ -38,30 +38,30 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 package hardfloat.test
 
 import hardfloat._
-import Chisel._
+import chisel3._
 
 class ValExec_AddRecFN(expWidth: Int, sigWidth: Int) extends Module
 {
-    val io = new Bundle {
-        val a = Bits(INPUT, expWidth + sigWidth)
-        val b = Bits(INPUT, expWidth + sigWidth)
-        val roundingMode   = UInt(INPUT, 3)
-        val detectTininess = UInt(INPUT, 1)
+    val io = IO(new Bundle {
+        val a = Input(Bits((expWidth + sigWidth).W))
+        val b = Input(Bits((expWidth + sigWidth).W))
+        val roundingMode   = Input(UInt(3.W))
+        val detectTininess = Input(UInt(1.W))
 
         val expected = new Bundle {
-            val out = Bits(INPUT, expWidth + sigWidth)
-            val exceptionFlags = Bits(INPUT, 5)
-            val recOut = Bits(OUTPUT, expWidth + sigWidth + 1)
+            val out = Input(Bits((expWidth + sigWidth).W))
+            val exceptionFlags = Input(Bits(5.W))
+            val recOut = Output(Bits((expWidth + sigWidth + 1).W))
         }
 
         val actual = new Bundle {
-            val out = Bits(OUTPUT, expWidth + sigWidth + 1)
-            val exceptionFlags = Bits(OUTPUT, 5)
+            val out = Output(Bits((expWidth + sigWidth + 1).W))
+            val exceptionFlags = Output(Bits(5.W))
         }
 
-        val check = Bool(OUTPUT)
-        val pass = Bool(OUTPUT)
-    }
+        val check = Output(Bool())
+        val pass = Output(Bool())
+    })
 
     val addRecFN = Module(new AddRecFN(expWidth, sigWidth))
     addRecFN.io.subOp := false.B
@@ -75,7 +75,7 @@ class ValExec_AddRecFN(expWidth: Int, sigWidth: Int) extends Module
     io.actual.out := addRecFN.io.out
     io.actual.exceptionFlags := addRecFN.io.exceptionFlags
 
-    io.check := Bool(true)
+    io.check := true.B
     io.pass :=
         equivRecFN(expWidth, sigWidth, io.actual.out, io.expected.recOut) &&
         (io.actual.exceptionFlags === io.expected.exceptionFlags)

--- a/src/test/scala/ValExec_CompareRecFN.scala
+++ b/src/test/scala/ValExec_CompareRecFN.scala
@@ -38,34 +38,34 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 package hardfloat.test
 
 import hardfloat._
-import Chisel._
+import chisel3._
 
 class ValExec_CompareRecFN_lt(expWidth: Int, sigWidth: Int) extends Module
 {
-    val io = new Bundle {
-        val a = Bits(INPUT, expWidth + sigWidth)
-        val b = Bits(INPUT, expWidth + sigWidth)
+    val io = IO(new Bundle {
+        val a = Input(Bits((expWidth + sigWidth).W))
+        val b = Input(Bits((expWidth + sigWidth).W))
         val expected = new Bundle {
-            val out = Bits(INPUT, 1)
-            val exceptionFlags = Bits(INPUT, 5)
+            val out = Input(Bits(1.W))
+            val exceptionFlags = Input(Bits(5.W))
         }
         val actual = new Bundle {
-            val out = Bits(OUTPUT, 1)
-            val exceptionFlags = Bits(OUTPUT, 5)
+            val out = Output(Bits(1.W))
+            val exceptionFlags = Output(Bits(5.W))
         }
-        val check = Bool(OUTPUT)
-        val pass = Bool(OUTPUT)
-    }
+        val check = Output(Bool())
+        val pass = Output(Bool())
+    })
 
     val compareRecFN = Module(new CompareRecFN(expWidth, sigWidth))
     compareRecFN.io.a := recFNFromFN(expWidth, sigWidth, io.a)
     compareRecFN.io.b := recFNFromFN(expWidth, sigWidth, io.b)
-    compareRecFN.io.signaling := Bool(true)
+    compareRecFN.io.signaling := true.B
 
     io.actual.out := compareRecFN.io.lt
     io.actual.exceptionFlags := compareRecFN.io.exceptionFlags
 
-    io.check := Bool(true)
+    io.check := true.B
     io.pass :=
         (io.actual.out === io.expected.out) &&
         (io.actual.exceptionFlags === io.expected.exceptionFlags)
@@ -73,30 +73,30 @@ class ValExec_CompareRecFN_lt(expWidth: Int, sigWidth: Int) extends Module
 
 class ValExec_CompareRecFN_le(expWidth: Int, sigWidth: Int) extends Module
 {
-    val io = new Bundle {
-        val a = Bits(INPUT, expWidth + sigWidth)
-        val b = Bits(INPUT, expWidth + sigWidth)
+    val io = IO(new Bundle {
+        val a = Input(Bits((expWidth + sigWidth).W))
+        val b = Input(Bits((expWidth + sigWidth).W))
         val expected = new Bundle {
-            val out = Bits(INPUT, 1)
-            val exceptionFlags = Bits(INPUT, 5)
+            val out = Input(Bits(1.W))
+            val exceptionFlags = Input(Bits(5.W))
         }
         val actual = new Bundle {
-            val out = Bits(OUTPUT, 1)
-            val exceptionFlags = Bits(OUTPUT, 5)
+            val out = Output(Bits(1.W))
+            val exceptionFlags = Output(Bits(5.W))
         }
-        val check = Bool(OUTPUT)
-        val pass = Bool(OUTPUT)
-    }
+        val check = Output(Bool())
+        val pass = Output(Bool())
+    })
 
     val compareRecFN = Module(new CompareRecFN(expWidth, sigWidth))
     compareRecFN.io.a := recFNFromFN(expWidth, sigWidth, io.a)
     compareRecFN.io.b := recFNFromFN(expWidth, sigWidth, io.b)
-    compareRecFN.io.signaling := Bool(true)
+    compareRecFN.io.signaling := true.B
 
     io.actual.out := compareRecFN.io.lt || compareRecFN.io.eq
     io.actual.exceptionFlags := compareRecFN.io.exceptionFlags
 
-    io.check := Bool(true)
+    io.check := true.B
     io.pass :=
         (io.actual.out === io.expected.out) &&
         (io.actual.exceptionFlags === io.expected.exceptionFlags)
@@ -104,30 +104,30 @@ class ValExec_CompareRecFN_le(expWidth: Int, sigWidth: Int) extends Module
 
 class ValExec_CompareRecFN_eq(expWidth: Int, sigWidth: Int) extends Module
 {
-    val io = new Bundle {
-        val a = Bits(INPUT, expWidth + sigWidth)
-        val b = Bits(INPUT, expWidth + sigWidth)
+    val io = IO(new Bundle {
+        val a = Input(Bits((expWidth + sigWidth).W))
+        val b = Input(Bits((expWidth + sigWidth).W))
         val expected = new Bundle {
-            val out = Bits(INPUT, 1)
-            val exceptionFlags = Bits(INPUT, 5)
+            val out = Input(Bits(1.W))
+            val exceptionFlags = Input(Bits(5.W))
         }
         val actual = new Bundle {
-            val out = Bits(OUTPUT, 1)
-            val exceptionFlags = Bits(OUTPUT, 5)
+            val out = Output(Bits(1.W))
+            val exceptionFlags = Output(Bits(5.W))
         }
-        val check = Bool(OUTPUT)
-        val pass = Bool(OUTPUT)
-    }
+        val check = Output(Bool())
+        val pass = Output(Bool())
+    })
 
     val compareRecFN = Module(new CompareRecFN(expWidth, sigWidth))
     compareRecFN.io.a := recFNFromFN(expWidth, sigWidth, io.a)
     compareRecFN.io.b := recFNFromFN(expWidth, sigWidth, io.b)
-    compareRecFN.io.signaling := Bool(false)
+    compareRecFN.io.signaling := false.B
 
     io.actual.out := compareRecFN.io.eq
     io.actual.exceptionFlags := compareRecFN.io.exceptionFlags
 
-    io.check := Bool(true)
+    io.check := true.B
     io.pass :=
         (io.actual.out === io.expected.out) &&
         (io.actual.exceptionFlags === io.expected.exceptionFlags)

--- a/src/test/scala/ValExec_DivSqrtRecF64.scala
+++ b/src/test/scala/ValExec_DivSqrtRecF64.scala
@@ -64,7 +64,7 @@ class ValExec_DivSqrtRecF64_div extends Module {
         val expected = new Bundle {
             val out = Output(Bits(64.W))
             val exceptionFlags = Output(Bits(5.W))
-            val recOut = Output(Bits(5.W))
+            val recOut = Output(Bits(65.W))
         }
 
         val actual = new Bundle {
@@ -154,6 +154,7 @@ class ValExec_DivSqrtRecF64_sqrt extends Module {
     ds.io.inValid := io.input.valid && cq.io.enq.ready
     ds.io.sqrtOp := true.B
     ds.io.b := recFNFromFN(11, 53, io.input.bits.b)
+    ds.io.a := DontCare
     ds.io.roundingMode   := io.input.bits.roundingMode
     ds.io.detectTininess := io.input.bits.detectTininess
 

--- a/src/test/scala/ValExec_DivSqrtRecF64.scala
+++ b/src/test/scala/ValExec_DivSqrtRecF64.scala
@@ -38,42 +38,43 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 package hardfloat.test
 
 import hardfloat._
-import Chisel._
+import chisel3._
+import chisel3.util._
 
 class DivRecF64_io extends Bundle {
-    val a = Bits(width = 64)
-    val b = Bits(width = 64)
-    val roundingMode   = UInt(width = 3)
-    val detectTininess = UInt(width = 1)
-    val out = Bits(width = 64)
-    val exceptionFlags = Bits(width = 5)
+    val a = Bits(64.W)
+    val b = Bits(64.W)
+    val roundingMode   = UInt(3.W)
+    val detectTininess = UInt(1.W)
+    val out = Bits(64.W)
+    val exceptionFlags = Bits(5.W)
 }
 
 class ValExec_DivSqrtRecF64_div extends Module {
-    val io = new Bundle {
-        val input = Decoupled(new DivRecF64_io).flip
+    val io = IO(new Bundle {
+        val input = Flipped(Decoupled(new DivRecF64_io))
 
         val output = new Bundle {
-            val a = Bits(OUTPUT, 64)
-            val b = Bits(OUTPUT, 64)
-            val roundingMode   = UInt(OUTPUT, 3)
-            val detectTininess = UInt(OUTPUT, 1)
+            val a = Output(Bits(64.W))
+            val b = Output(Bits(64.W))
+            val roundingMode   = Output(UInt(3.W))
+            val detectTininess = Output(UInt(1.W))
         }
 
         val expected = new Bundle {
-            val out = Bits(OUTPUT, 64)
-            val exceptionFlags = Bits(OUTPUT, 5)
-            val recOut = Bits(OUTPUT, 65)
+            val out = Output(Bits(64.W))
+            val exceptionFlags = Output(Bits(5.W))
+            val recOut = Output(Bits(5.W))
         }
 
         val actual = new Bundle {
-            val out = Bits(OUTPUT, 65)
-            val exceptionFlags = Bits(OUTPUT, 5)
+            val out = Output(Bits(65.W))
+            val exceptionFlags = Output(Bits(5.W))
         }
 
-        val check = Bool(OUTPUT)
-        val pass = Bool(OUTPUT)
-    }
+        val check = Output(Bool())
+        val pass = Output(Bool())
+    })
 
     val ds = Module(new DivSqrtRecF64)
     val cq = Module(new Queue(new DivRecF64_io, 5))
@@ -83,7 +84,7 @@ class ValExec_DivSqrtRecF64_div extends Module {
 
     io.input.ready := ds.io.inReady_div && cq.io.enq.ready
     ds.io.inValid := io.input.valid && cq.io.enq.ready
-    ds.io.sqrtOp := Bool(false)
+    ds.io.sqrtOp := false.B
     ds.io.a := recFNFromFN(11, 53, io.input.bits.a)
     ds.io.b := recFNFromFN(11, 53, io.input.bits.b)
     ds.io.roundingMode   := io.input.bits.roundingMode
@@ -111,37 +112,37 @@ class ValExec_DivSqrtRecF64_div extends Module {
 }
 
 class SqrtRecF64_io extends Bundle {
-    val b = Bits(width = 64)
-    val roundingMode   = UInt(width = 3)
-    val detectTininess = UInt(width = 1)
-    val out = Bits(width = 64)
-    val exceptionFlags = Bits(width = 5)
+    val b = Bits(64.W)
+    val roundingMode   = UInt(3.W)
+    val detectTininess = UInt(1.W)
+    val out = Bits(64.W)
+    val exceptionFlags = Bits(5.W)
 }
 
 class ValExec_DivSqrtRecF64_sqrt extends Module {
-    val io = new Bundle {
-        val input = Decoupled(new SqrtRecF64_io).flip
+    val io = IO(new Bundle {
+        val input = Flipped(Decoupled(new SqrtRecF64_io))
 
         val output = new Bundle {
-            val b = Bits(OUTPUT, 64)
-            val roundingMode   = UInt(OUTPUT, 3)
-            val detectTininess = UInt(OUTPUT, 1)
+            val b = Output(Bits(64.W))
+            val roundingMode   = Output(UInt(3.W))
+            val detectTininess = Output(UInt(1.W))
         }
 
         val expected = new Bundle {
-            val out = Bits(OUTPUT, 64)
-            val exceptionFlags = Bits(OUTPUT, 5)
-            val recOut = Bits(OUTPUT, 65)
+            val out = Output(Bits(64.W))
+            val exceptionFlags = Output(Bits(5.W))
+            val recOut = Output(Bits(65.W))
         }
 
         val actual = new Bundle {
-            val out = Bits(OUTPUT, 65)
-            val exceptionFlags = Bits(OUTPUT, 5)
+            val out = Output(Bits(65.W))
+            val exceptionFlags = Output(Bits(5.W))
         }
 
-        val check = Bool(OUTPUT)
-        val pass = Bool(OUTPUT)
-    }
+        val check = Output(Bool())
+        val pass = Output(Bool())
+    })
 
     val ds = Module(new DivSqrtRecF64)
     val cq = Module(new Queue(new SqrtRecF64_io, 5))
@@ -151,7 +152,7 @@ class ValExec_DivSqrtRecF64_sqrt extends Module {
 
     io.input.ready := ds.io.inReady_sqrt && cq.io.enq.ready
     ds.io.inValid := io.input.valid && cq.io.enq.ready
-    ds.io.sqrtOp := Bool(true)
+    ds.io.sqrtOp := true.B
     ds.io.b := recFNFromFN(11, 53, io.input.bits.b)
     ds.io.roundingMode   := io.input.bits.roundingMode
     ds.io.detectTininess := io.input.bits.detectTininess

--- a/src/test/scala/ValExec_DivSqrtRecFN_small.scala
+++ b/src/test/scala/ValExec_DivSqrtRecFN_small.scala
@@ -37,45 +37,46 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 package hardfloat.test
 
 import hardfloat._
-import Chisel._
+import chisel3._
+import chisel3.util._
 
 class DivRecFN_io(expWidth: Int, sigWidth: Int) extends Bundle {
-    val a = Bits(width = expWidth + sigWidth)
-    val b = Bits(width = expWidth + sigWidth)
-    val roundingMode   = UInt(width = 3)
-    val detectTininess = UInt(width = 1)
-    val out = Bits(width = expWidth + sigWidth)
-    val exceptionFlags = Bits(width = 5)
+    val a = Bits((expWidth + sigWidth).W)
+    val b = Bits((expWidth + sigWidth).W)
+    val roundingMode   = UInt(3.W)
+    val detectTininess = UInt(1.W)
+    val out = Bits((expWidth + sigWidth).W)
+    val exceptionFlags = Bits(5.W)
 
 }
 
 class
     ValExec_DivSqrtRecFN_small_div(expWidth: Int, sigWidth: Int, options: Int) extends Module
 {
-    val io = new Bundle {
-        val input = Decoupled(new DivRecFN_io(expWidth, sigWidth)).flip
+    val io = IO(new Bundle {
+        val input = Flipped(Decoupled(new DivRecFN_io(expWidth, sigWidth)))
 
         val output = new Bundle {
-            val a = Bits(OUTPUT, expWidth + sigWidth)
-            val b = Bits(OUTPUT, expWidth + sigWidth)
-            val roundingMode   = UInt(OUTPUT, 3)
-            val detectTininess = UInt(OUTPUT, 1)
+            val a = Flipped(Bits((expWidth + sigWidth).W))
+            val b = Flipped(Bits((expWidth + sigWidth).W))
+            val roundingMode   = Output(UInt(3.W))
+            val detectTininess = Output(UInt(1.W))
         }
 
         val expected = new Bundle {
-            val out = Bits(OUTPUT, expWidth + sigWidth)
-            val exceptionFlags = Bits(OUTPUT, 5)
-            val recOut = Bits(OUTPUT, expWidth + sigWidth + 1)
+            val out = Output(Bits((expWidth + sigWidth).W))
+            val exceptionFlags = Output(Bits(5.W))
+            val recOut = Output(Bits((expWidth + sigWidth + 1).W))
         }
 
         val actual = new Bundle {
-            val out = Bits(OUTPUT, expWidth + sigWidth + 1)
-            val exceptionFlags = Bits(OUTPUT, 5)
+            val out = Output(Bits((expWidth + sigWidth + 1).W))
+            val exceptionFlags = Output(Bits(5.W))
         }
 
-        val check = Bool(OUTPUT)
-        val pass = Bool(OUTPUT)
-    }
+        val check = Output(Bool())
+        val pass = Output(Bool())
+    })
 
     val ds = Module(new DivSqrtRecFN_small(expWidth, sigWidth, options))
     val cq = Module(new Queue(new DivRecFN_io(expWidth, sigWidth), 5))
@@ -85,7 +86,7 @@ class
 
     io.input.ready := ds.io.inReady && cq.io.enq.ready
     ds.io.inValid := io.input.valid && cq.io.enq.ready
-    ds.io.sqrtOp := Bool(false)
+    ds.io.sqrtOp := false.B
     ds.io.a := recFNFromFN(expWidth, sigWidth, io.input.bits.a)
     ds.io.b := recFNFromFN(expWidth, sigWidth, io.input.bits.b)
     ds.io.roundingMode   := io.input.bits.roundingMode
@@ -113,11 +114,11 @@ class
 }
 
 class SqrtRecFN_io(expWidth: Int, sigWidth: Int) extends Bundle {
-    val a = Bits(width = expWidth + sigWidth)
-    val roundingMode   = UInt(width = 3)
-    val detectTininess = UInt(width = 1)
-    val out = Bits(width = expWidth + sigWidth)
-    val exceptionFlags = Bits(width = 5)
+    val a = Bits((expWidth + sigWidth).W)
+    val roundingMode   = UInt(3.W)
+    val detectTininess = UInt(1.W)
+    val out = Bits((expWidth + sigWidth).W)
+    val exceptionFlags = Bits(5.W)
 
 }
 
@@ -125,29 +126,29 @@ class
     ValExec_DivSqrtRecFN_small_sqrt(expWidth: Int, sigWidth: Int, options: Int)
     extends Module
 {
-    val io = new Bundle {
-        val input = Decoupled(new SqrtRecFN_io(expWidth, sigWidth)).flip
+    val io = IO(new Bundle {
+        val input = Flipped(Decoupled(new SqrtRecFN_io(expWidth, sigWidth)))
 
         val output = new Bundle {
-            val a = Bits(OUTPUT, expWidth + sigWidth)
-            val roundingMode   = UInt(OUTPUT, 3)
-            val detectTininess = UInt(OUTPUT, 1)
+            val a = Output(Bits((expWidth + sigWidth).W))
+            val roundingMode   = Output(UInt(3.W))
+            val detectTininess = Output(UInt(1.W))
         }
 
         val expected = new Bundle {
-            val out = Bits(OUTPUT, expWidth + sigWidth)
-            val exceptionFlags = Bits(OUTPUT, 5)
-            val recOut = Bits(OUTPUT, expWidth + sigWidth + 1)
+            val out = Output(Bits((expWidth + sigWidth).W))
+            val exceptionFlags = Output(Bits(5.W))
+            val recOut = Output(Bits((expWidth + sigWidth + 1).W))
         }
 
         val actual = new Bundle {
-            val out = Bits(OUTPUT, expWidth + sigWidth + 1)
-            val exceptionFlags = Bits(OUTPUT, 5)
+            val out = Output(Bits((expWidth + sigWidth + 1).W))
+            val exceptionFlags = Output(Bits(5.W))
         }
 
-        val check = Bool(OUTPUT)
-        val pass = Bool(OUTPUT)
-    }
+        val check = Output(Bool())
+        val pass = Output(Bool())
+    })
 
     val ds = Module(new DivSqrtRecFN_small(expWidth, sigWidth, options))
     val cq = Module(new Queue(new SqrtRecFN_io(expWidth, sigWidth), 5))
@@ -157,7 +158,7 @@ class
 
     io.input.ready := ds.io.inReady && cq.io.enq.ready
     ds.io.inValid := io.input.valid && cq.io.enq.ready
-    ds.io.sqrtOp := Bool(true)
+    ds.io.sqrtOp := true.B
     ds.io.a := recFNFromFN(expWidth, sigWidth, io.input.bits.a)
     ds.io.roundingMode   := io.input.bits.roundingMode
     ds.io.detectTininess := io.input.bits.detectTininess

--- a/src/test/scala/ValExec_DivSqrtRecFN_small.scala
+++ b/src/test/scala/ValExec_DivSqrtRecFN_small.scala
@@ -57,8 +57,8 @@ class
         val input = Flipped(Decoupled(new DivRecFN_io(expWidth, sigWidth)))
 
         val output = new Bundle {
-            val a = Flipped(Bits((expWidth + sigWidth).W))
-            val b = Flipped(Bits((expWidth + sigWidth).W))
+            val a = Flipped(Input(Bits((expWidth + sigWidth).W)))
+            val b = Flipped(Input(Bits((expWidth + sigWidth).W)))
             val roundingMode   = Output(UInt(3.W))
             val detectTininess = Output(UInt(1.W))
         }
@@ -160,6 +160,7 @@ class
     ds.io.inValid := io.input.valid && cq.io.enq.ready
     ds.io.sqrtOp := true.B
     ds.io.a := recFNFromFN(expWidth, sigWidth, io.input.bits.a)
+    ds.io.b := DontCare
     ds.io.roundingMode   := io.input.bits.roundingMode
     ds.io.detectTininess := io.input.bits.detectTininess
 

--- a/src/test/scala/ValExec_INToRecFN.scala
+++ b/src/test/scala/ValExec_INToRecFN.scala
@@ -52,7 +52,7 @@ class
         val expected = new Bundle {
             val out = Input(Bits((expWidth + sigWidth).W))
             val exceptionFlags = Input(Bits(5.W))
-            val recOut = Input(Bits((expWidth + sigWidth + 1).W))
+            val recOut = Output(Bits((expWidth + sigWidth + 1).W))
         }
 
         val actual = new Bundle {
@@ -85,10 +85,10 @@ class
     ValExec_INToRecFN(intWidth: Int, expWidth: Int, sigWidth: Int)
     extends Module
 {
-    val io = new Bundle {
+    val io = IO(new Bundle {
         val in = Input(Bits(intWidth.W))
         val roundingMode   = Input(UInt(3.W))
-        val detectTininess = UInt(1.W)
+        val detectTininess = Input(UInt(1.W))
 
         val expected = new Bundle {
             val out = Input(Bits((expWidth + sigWidth).W))
@@ -103,7 +103,7 @@ class
 
         val check = Output(Bool())
         val pass = Output(Bool())
-    }
+    })
 
     val iNToRecFN = Module(new INToRecFN(intWidth, expWidth, sigWidth))
     iNToRecFN.io.signedIn := true.B

--- a/src/test/scala/ValExec_INToRecFN.scala
+++ b/src/test/scala/ValExec_INToRecFN.scala
@@ -38,34 +38,34 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 package hardfloat.test
 
 import hardfloat._
-import Chisel._
+import chisel3._
 
 class
     ValExec_UINToRecFN(intWidth: Int, expWidth: Int, sigWidth: Int)
     extends Module
 {
-    val io = new Bundle {
-        val in = Bits(INPUT, intWidth)
-        val roundingMode   = UInt(INPUT, 3)
-        val detectTininess = UInt(INPUT, 1)
+    val io = IO(new Bundle {
+        val in = Input(Bits(intWidth.W))
+        val roundingMode   = Input(UInt(3.W))
+        val detectTininess = Input(UInt(1.W))
 
         val expected = new Bundle {
-            val out = Bits(INPUT, expWidth + sigWidth)
-            val exceptionFlags = Bits(INPUT, 5)
-            val recOut = Bits(OUTPUT, expWidth + sigWidth + 1)
+            val out = Input(Bits((expWidth + sigWidth).W))
+            val exceptionFlags = Input(Bits(5.W))
+            val recOut = Input(Bits((expWidth + sigWidth + 1).W))
         }
 
         val actual = new Bundle {
-            val out = Bits(OUTPUT, expWidth + sigWidth + 1)
-            val exceptionFlags = Bits(OUTPUT, 5)
+            val out = Output(Bits((expWidth + sigWidth + 1).W))
+            val exceptionFlags = Output(Bits(5.W))
         }
 
-        val check = Bool(OUTPUT)
-        val pass = Bool(OUTPUT)
-    }
+        val check = Output(Bool())
+        val pass = Output(Bool())
+    })
 
     val iNToRecFN = Module(new INToRecFN(intWidth, expWidth, sigWidth))
-    iNToRecFN.io.signedIn := Bool(false)
+    iNToRecFN.io.signedIn := false.B
     iNToRecFN.io.in := io.in
     iNToRecFN.io.roundingMode   := io.roundingMode
     iNToRecFN.io.detectTininess := io.detectTininess
@@ -75,7 +75,7 @@ class
     io.actual.out := iNToRecFN.io.out
     io.actual.exceptionFlags := iNToRecFN.io.exceptionFlags
 
-    io.check := Bool(true)
+    io.check := true.B
     io.pass :=
         equivRecFN(expWidth, sigWidth, io.actual.out, io.expected.recOut) &&
         (io.actual.exceptionFlags === io.expected.exceptionFlags)
@@ -86,27 +86,27 @@ class
     extends Module
 {
     val io = new Bundle {
-        val in = Bits(INPUT, intWidth)
-        val roundingMode   = UInt(INPUT, 3)
-        val detectTininess = UInt(INPUT, 1)
+        val in = Input(Bits(intWidth.W))
+        val roundingMode   = Input(UInt(3.W))
+        val detectTininess = UInt(1.W)
 
         val expected = new Bundle {
-            val out = Bits(INPUT, expWidth + sigWidth)
-            val exceptionFlags = Bits(INPUT, 5)
-            val recOut = Bits(OUTPUT, expWidth + sigWidth + 1)
+            val out = Input(Bits((expWidth + sigWidth).W))
+            val exceptionFlags = Input(Bits(5.W))
+            val recOut = Output(Bits((expWidth + sigWidth + 1).W))
         }
 
         val actual = new Bundle {
-            val out = Bits(OUTPUT, expWidth + sigWidth + 1)
-            val exceptionFlags = Bits(OUTPUT, 5)
+            val out = Output(Bits((expWidth + sigWidth + 1).W))
+            val exceptionFlags = Output(Bits(5.W))
         }
 
-        val check = Bool(OUTPUT)
-        val pass = Bool(OUTPUT)
+        val check = Output(Bool())
+        val pass = Output(Bool())
     }
 
     val iNToRecFN = Module(new INToRecFN(intWidth, expWidth, sigWidth))
-    iNToRecFN.io.signedIn := Bool(true)
+    iNToRecFN.io.signedIn := true.B
     iNToRecFN.io.in := io.in
     iNToRecFN.io.roundingMode   := io.roundingMode
     iNToRecFN.io.detectTininess := io.detectTininess
@@ -116,7 +116,7 @@ class
     io.actual.out := iNToRecFN.io.out
     io.actual.exceptionFlags := iNToRecFN.io.exceptionFlags
 
-    io.check := Bool(true)
+    io.check := true.B
     io.pass :=
         equivRecFN(expWidth, sigWidth, io.actual.out, io.expected.recOut) &&
         (io.actual.exceptionFlags === io.expected.exceptionFlags)

--- a/src/test/scala/ValExec_MulAddRecFN.scala
+++ b/src/test/scala/ValExec_MulAddRecFN.scala
@@ -38,34 +38,34 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 package hardfloat.test
 
 import hardfloat._
-import Chisel._
+import chisel3._
 
 class ValExec_MulAddRecFN(expWidth: Int, sigWidth: Int) extends Module
 {
-    val io = new Bundle {
-        val a = Bits(INPUT, expWidth + sigWidth)
-        val b = Bits(INPUT, expWidth + sigWidth)
-        val c = Bits(INPUT, expWidth + sigWidth)
-        val roundingMode   = UInt(INPUT, 3)
-        val detectTininess = UInt(INPUT, 1)
+    val io = IO(new Bundle {
+        val a = Input(Bits((expWidth + sigWidth).W))
+        val b = Input(Bits((expWidth + sigWidth).W))
+        val c = Input(Bits((expWidth + sigWidth).W))
+        val roundingMode   = Input(UInt(3.W))
+        val detectTininess = Input(UInt(1.W))
 
         val expected = new Bundle {
-            val out = Bits(INPUT, expWidth + sigWidth)
-            val exceptionFlags = Bits(INPUT, 5)
-            val recOut = Bits(OUTPUT, expWidth + sigWidth + 1)
+            val out = Input(Bits((expWidth + sigWidth).W))
+            val exceptionFlags = Input(Bits(5.W))
+            val recOut = Output(Bits((expWidth + sigWidth + 1).W))
         }
 
         val actual = new Bundle {
-            val out = Bits(OUTPUT, expWidth + sigWidth + 1)
-            val exceptionFlags = Bits(OUTPUT, 5)
+            val out = Output(Bits((expWidth + sigWidth + 1).W))
+            val exceptionFlags = Output(Bits(5.W))
         }
 
-        val check = Bool(OUTPUT)
-        val pass = Bool(OUTPUT)
-    }
+        val check = Output(Bool())
+        val pass = Output(Bool())
+    })
 
     val mulAddRecFN = Module(new MulAddRecFN(expWidth, sigWidth))
-    mulAddRecFN.io.op := UInt(0)
+    mulAddRecFN.io.op := 0.U
     mulAddRecFN.io.a := recFNFromFN(expWidth, sigWidth, io.a)
     mulAddRecFN.io.b := recFNFromFN(expWidth, sigWidth, io.b)
     mulAddRecFN.io.c := recFNFromFN(expWidth, sigWidth, io.c)
@@ -77,7 +77,7 @@ class ValExec_MulAddRecFN(expWidth: Int, sigWidth: Int) extends Module
     io.actual.out := mulAddRecFN.io.out
     io.actual.exceptionFlags := mulAddRecFN.io.exceptionFlags
 
-    io.check := Bool(true)
+    io.check := true.B
     io.pass :=
         equivRecFN(expWidth, sigWidth, io.actual.out, io.expected.recOut) &&
         (io.actual.exceptionFlags === io.expected.exceptionFlags)
@@ -85,31 +85,31 @@ class ValExec_MulAddRecFN(expWidth: Int, sigWidth: Int) extends Module
 
 class ValExec_MulAddRecFN_add(expWidth: Int, sigWidth: Int) extends Module
 {
-    val io = new Bundle {
-        val a = Bits(INPUT, expWidth + sigWidth)
-        val b = Bits(INPUT, expWidth + sigWidth)
-        val roundingMode   = UInt(INPUT, 3)
-        val detectTininess = UInt(INPUT, 1)
+    val io = IO(new Bundle {
+        val a = Input(Bits((expWidth + sigWidth).W))
+        val b = Input(Bits((expWidth + sigWidth).W))
+        val roundingMode   = Input(UInt(3.W))
+        val detectTininess = Input(UInt(1.W))
 
         val expected = new Bundle {
-            val out = Bits(INPUT, expWidth + sigWidth)
-            val exceptionFlags = Bits(INPUT, 5)
-            val recOut = Bits(OUTPUT, expWidth + sigWidth + 1)
+            val out = Input(Bits((expWidth + sigWidth).W))
+            val exceptionFlags = Input(Bits(5.W))
+            val recOut = Output(Bits((expWidth + sigWidth + 1).W))
         }
 
         val actual = new Bundle {
-            val out = Bits(OUTPUT, expWidth + sigWidth + 1)
-            val exceptionFlags = Bits(OUTPUT, 5)
+            val out = Output(Bits((expWidth + sigWidth + 1).W))
+            val exceptionFlags = Output(Bits(5.W))
         }
 
-        val check = Bool(OUTPUT)
-        val pass = Bool(OUTPUT)
-    }
+        val check = Output(Bool())
+        val pass = Output(Bool())
+    })
 
     val mulAddRecFN = Module(new MulAddRecFN(expWidth, sigWidth))
-    mulAddRecFN.io.op := UInt(0)
+    mulAddRecFN.io.op := 0.U
     mulAddRecFN.io.a := recFNFromFN(expWidth, sigWidth, io.a)
-    mulAddRecFN.io.b := UInt(BigInt(1)<<(expWidth + sigWidth - 1))
+    mulAddRecFN.io.b := (BigInt(1)<<(expWidth + sigWidth - 1)).U
     mulAddRecFN.io.c := recFNFromFN(expWidth, sigWidth, io.b)
     mulAddRecFN.io.roundingMode   := io.roundingMode
     mulAddRecFN.io.detectTininess := io.detectTininess
@@ -119,7 +119,7 @@ class ValExec_MulAddRecFN_add(expWidth: Int, sigWidth: Int) extends Module
     io.actual.out := mulAddRecFN.io.out
     io.actual.exceptionFlags := mulAddRecFN.io.exceptionFlags
 
-    io.check := Bool(true)
+    io.check := true.B
     io.pass :=
         equivRecFN(expWidth, sigWidth, io.actual.out, io.expected.recOut) &&
         (io.actual.exceptionFlags === io.expected.exceptionFlags)
@@ -127,33 +127,32 @@ class ValExec_MulAddRecFN_add(expWidth: Int, sigWidth: Int) extends Module
 
 class ValExec_MulAddRecFN_mul(expWidth: Int, sigWidth: Int) extends Module
 {
-    val io = new Bundle {
-        val a = Bits(INPUT, expWidth + sigWidth)
-        val b = Bits(INPUT, expWidth + sigWidth)
-        val roundingMode   = UInt(INPUT, 3)
-        val detectTininess = UInt(INPUT, 1)
+    val io = IO(new Bundle {
+        val a = Input(Bits((expWidth + sigWidth).W))
+        val b = Input(Bits((expWidth + sigWidth).W))
+        val roundingMode   = Input(UInt(3.W))
+        val detectTininess = Input(UInt(1.W))
 
         val expected = new Bundle {
-            val out = Bits(INPUT, expWidth + sigWidth)
-            val exceptionFlags = Bits(INPUT, 5)
-            val recOut = Bits(OUTPUT, expWidth + sigWidth + 1)
+            val out = Input(Bits((expWidth + sigWidth).W))
+            val exceptionFlags = Input(Bits(5.W))
+            val recOut = Output(Bits((expWidth + sigWidth + 1).W))
         }
 
         val actual = new Bundle {
-            val out = Bits(OUTPUT, expWidth + sigWidth + 1)
-            val exceptionFlags = Bits(OUTPUT, 5)
+            val out = Output(Bits((expWidth + sigWidth + 1).W))
+            val exceptionFlags = Output(Bits(5.W))
         }
 
-        val check = Bool(OUTPUT)
-        val pass = Bool(OUTPUT)
-    }
-
+        val check = Output(Bool())
+        val pass = Output(Bool())
+    })
     val mulAddRecFN = Module(new MulAddRecFN(expWidth, sigWidth))
-    mulAddRecFN.io.op := UInt(0)
+    mulAddRecFN.io.op := 0.U
     mulAddRecFN.io.a := recFNFromFN(expWidth, sigWidth, io.a)
     mulAddRecFN.io.b := recFNFromFN(expWidth, sigWidth, io.b)
     mulAddRecFN.io.c :=
-        ((io.a ^ io.b) & UInt(BigInt(1)<<(expWidth + sigWidth - 1)))<<1
+        ((io.a ^ io.b) & (BigInt(1)<<(expWidth + sigWidth - 1)).U)<<1
     mulAddRecFN.io.roundingMode   := io.roundingMode
     mulAddRecFN.io.detectTininess := io.detectTininess
 
@@ -162,7 +161,7 @@ class ValExec_MulAddRecFN_mul(expWidth: Int, sigWidth: Int) extends Module
     io.actual.out := mulAddRecFN.io.out
     io.actual.exceptionFlags := mulAddRecFN.io.exceptionFlags
 
-    io.check := Bool(true)
+    io.check := true.B
     io.pass :=
         equivRecFN(expWidth, sigWidth, io.actual.out, io.expected.recOut) &&
         (io.actual.exceptionFlags === io.expected.exceptionFlags)

--- a/src/test/scala/ValExec_MulRecFN.scala
+++ b/src/test/scala/ValExec_MulRecFN.scala
@@ -37,31 +37,31 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 package hardfloat.test
 
+import chisel3._
 import hardfloat._
-import Chisel._
 
 class ValExec_MulRecFN(expWidth: Int, sigWidth: Int) extends Module
 {
-    val io = new Bundle {
-        val a = Bits(INPUT, expWidth + sigWidth)
-        val b = Bits(INPUT, expWidth + sigWidth)
-        val roundingMode   = UInt(INPUT, 3)
-        val detectTininess = UInt(INPUT, 1)
+    val io = IO(new Bundle {
+        val a = Input(Bits((expWidth + sigWidth).W))
+        val b = Input(Bits((expWidth + sigWidth).W))
+        val roundingMode   = Input(UInt(3.W))
+        val detectTininess = Input(UInt(1.W))
 
         val expected = new Bundle {
-            val out = Bits(INPUT, expWidth + sigWidth)
-            val exceptionFlags = Bits(INPUT, 5)
-            val recOut = Bits(OUTPUT, expWidth + sigWidth + 1)
+            val out = Input(Bits((expWidth + sigWidth).W))
+            val exceptionFlags = Input(Bits(5.W))
+            val recOut = Output(Bits((expWidth + sigWidth + 1).W))
         }
 
         val actual = new Bundle {
-            val out = Bits(OUTPUT, expWidth + sigWidth + 1)
-            val exceptionFlags = Bits(OUTPUT, 5)
+            val out = Output(Bits((expWidth + sigWidth + 1).W))
+            val exceptionFlags = Output(Bits(5.W))
         }
 
-        val check = Bool(OUTPUT)
-        val pass = Bool(OUTPUT)
-    }
+        val check = Output(Bool())
+        val pass = Output(Bool())
+    })
 
     val mulRecFN = Module(new MulRecFN(expWidth, sigWidth))
     mulRecFN.io.a := recFNFromFN(expWidth, sigWidth, io.a)
@@ -74,7 +74,7 @@ class ValExec_MulRecFN(expWidth: Int, sigWidth: Int) extends Module
     io.actual.out := mulRecFN.io.out
     io.actual.exceptionFlags := mulRecFN.io.exceptionFlags
 
-    io.check := Bool(true)
+    io.check := true.B
     io.pass :=
         equivRecFN(expWidth, sigWidth, io.actual.out, io.expected.recOut) &&
         (io.actual.exceptionFlags === io.expected.exceptionFlags)

--- a/src/test/scala/ValExec_RecFNToIN.scala
+++ b/src/test/scala/ValExec_RecFNToIN.scala
@@ -38,43 +38,42 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 package hardfloat.test
 
 import hardfloat._
-import Chisel._
+import chisel3._
 
 class
     ValExec_RecFNToUIN(expWidth: Int, sigWidth: Int, intWidth: Int)
     extends Module
 {
-    val io = new Bundle {
-        val in = Bits(INPUT, expWidth + sigWidth)
-        val roundingMode = UInt(INPUT, 3)
+    val io = IO(new Bundle {
+        val in = Input(Bits((expWidth + sigWidth).W))
+        val roundingMode   = Input(UInt(3.W))
 
         val expected = new Bundle {
-            val out = Bits(INPUT, intWidth)
-            val exceptionFlags = Bits(INPUT, 5)
+            val out = Input(Bits(intWidth.W))
+            val exceptionFlags = Input(Bits(5.W))
         }
 
         val actual = new Bundle {
-            val out = Bits(OUTPUT, intWidth)
-            val exceptionFlags = Bits(OUTPUT, 5)
+            val out = Output(Bits(intWidth.W))
+            val exceptionFlags = Output(Bits(5.W))
         }
 
-        val check = Bool(OUTPUT)
-        val pass = Bool(OUTPUT)
-    }
-
+        val check = Output(Bool())
+        val pass = Output(Bool())
+    })
     val recFNToIN = Module(new RecFNToIN(expWidth, sigWidth, intWidth))
     recFNToIN.io.in := recFNFromFN(expWidth, sigWidth, io.in)
     recFNToIN.io.roundingMode := io.roundingMode
-    recFNToIN.io.signedOut := Bool(false)
+    recFNToIN.io.signedOut := false.B
 
     io.actual.out := recFNToIN.io.out
     io.actual.exceptionFlags :=
-        Cat(recFNToIN.io.intExceptionFlags(2, 1).orR,
-            UInt(0, 3),
+        recFNToIN.io.intExceptionFlags(2, 1).orR ##
+            0.U(3.W) ##
             recFNToIN.io.intExceptionFlags(0)
-        )
 
-    io.check := Bool(true)
+
+    io.check := true.B
     io.pass :=
         (io.actual.out === io.expected.out) &&
         (io.actual.exceptionFlags === io.expected.exceptionFlags)
@@ -85,37 +84,37 @@ class
     ValExec_RecFNToIN(expWidth: Int, sigWidth: Int, intWidth: Int)
     extends Module
 {
-    val io = new Bundle {
-        val in = Bits(INPUT, expWidth + sigWidth)
-        val roundingMode = UInt(INPUT, 3)
+    val io = IO(new Bundle {
+        val in = Input(Bits((expWidth + sigWidth).W))
+        val roundingMode   = Input(UInt(3.W))
 
         val expected = new Bundle {
-            val out = Bits(INPUT, intWidth)
-            val exceptionFlags = Bits(INPUT, 5)
+            val out = Input(Bits(intWidth.W))
+            val exceptionFlags = Input(Bits(5.W))
         }
 
         val actual = new Bundle {
-            val out = Bits(OUTPUT, intWidth)
-            val exceptionFlags = Bits(OUTPUT, 5)
+            val out = Output(Bits(intWidth.W))
+            val exceptionFlags = Output(Bits(5.W))
         }
 
-        val check = Bool(OUTPUT)
-        val pass = Bool(OUTPUT)
-    }
+        val check = Output(Bool())
+        val pass = Output(Bool())
+    })
 
     val recFNToIN = Module(new RecFNToIN(expWidth, sigWidth, intWidth))
     recFNToIN.io.in := recFNFromFN(expWidth, sigWidth, io.in)
     recFNToIN.io.roundingMode := io.roundingMode
-    recFNToIN.io.signedOut := Bool(true)
+    recFNToIN.io.signedOut := true.B
 
     io.actual.out := recFNToIN.io.out
     io.actual.exceptionFlags :=
-        Cat(recFNToIN.io.intExceptionFlags(2, 1).orR,
-            UInt(0, 3),
-            recFNToIN.io.intExceptionFlags(0)
-        )
+        recFNToIN.io.intExceptionFlags(2, 1).orR ##
+          0.U(3.W) ##
+          recFNToIN.io.intExceptionFlags(0)
 
-    io.check := Bool(true)
+
+    io.check := true.B
     io.pass :=
         (io.actual.out === io.expected.out) &&
         (io.actual.exceptionFlags === io.expected.exceptionFlags)

--- a/src/test/scala/ValExec_RecFNToRecFN.scala
+++ b/src/test/scala/ValExec_RecFNToRecFN.scala
@@ -38,32 +38,32 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 package hardfloat.test
 
 import hardfloat._
-import Chisel._
+import chisel3._
 
 class
     ValExec_RecFNToRecFN(
         inExpWidth: Int, inSigWidth: Int, outExpWidth: Int, outSigWidth: Int)
     extends Module
 {
-    val io = new Bundle {
-        val in = Bits(INPUT, inExpWidth + inSigWidth)
-        val roundingMode   = UInt(INPUT, 3)
-        val detectTininess = UInt(INPUT, 1)
+    val io = IO(new Bundle {
+        val in = Input(Bits((inExpWidth + inSigWidth).W))
+        val roundingMode   = Input(UInt(3.W))
+        val detectTininess = Input(UInt(1.W))
 
         val expected = new Bundle {
-            val out = Bits(INPUT, outExpWidth + outSigWidth)
-            val exceptionFlags = Bits(INPUT, 5)
-            val recOut = Bits(OUTPUT, outExpWidth + outSigWidth + 1)
+            val out = Input(Bits((outExpWidth + outSigWidth).W))
+            val exceptionFlags = Input(Bits(5.W))
+            val recOut = Output(Bits((outExpWidth + outSigWidth + 1).W))
         }
 
         val actual = new Bundle {
-            val out = Bits(OUTPUT, outExpWidth + outSigWidth + 1)
-            val exceptionFlags = Bits(OUTPUT, 5)
+            val out = Output(Bits((outExpWidth + outSigWidth + 1).W))
+            val exceptionFlags = Output(Bits(5.W))
         }
 
-        val check = Bool(OUTPUT)
-        val pass = Bool(OUTPUT)
-    }
+        val check = Output(Bool())
+        val pass = Output(Bool())
+    })
 
     val recFNToRecFN =
         Module(
@@ -78,7 +78,7 @@ class
     io.actual.out := recFNToRecFN.io.out
     io.actual.exceptionFlags := recFNToRecFN.io.exceptionFlags
 
-    io.check := Bool(true)
+    io.check := true.B
     io.pass :=
         equivRecFN(
             outExpWidth, outSigWidth, io.actual.out, io.expected.recOut) &&

--- a/src/test/scala/ValExec_fNFromRecFN.scala
+++ b/src/test/scala/ValExec_fNFromRecFN.scala
@@ -38,21 +38,21 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 package hardfloat.test
 
 import hardfloat._
-import Chisel._
+import chisel3._
 
 class ValExec_fNFromRecFN(expWidth: Int, sigWidth: Int) extends Module
 {
-    val io = new Bundle {
-        val a = Bits(INPUT, expWidth + sigWidth)
-        val out = Bits(OUTPUT, expWidth + sigWidth)
-        val check = Bool(OUTPUT)
-        val pass = Bool(OUTPUT)
-    }
+    val io = IO(new Bundle {
+        val a = Output(Bits((expWidth + sigWidth).W))
+        val out = Output(Bits((expWidth + sigWidth).W))
+        val check = Output(Bool())
+        val pass = Output(Bool())
+    })
 
     io.out :=
         fNFromRecFN(expWidth, sigWidth, recFNFromFN(expWidth, sigWidth, io.a))
 
-    io.check := Bool(true)
+    io.check := true.B
     io.pass := (io.out === io.a)
 }
 

--- a/src/test/scala/ValExec_fNFromRecFN.scala
+++ b/src/test/scala/ValExec_fNFromRecFN.scala
@@ -43,7 +43,7 @@ import chisel3._
 class ValExec_fNFromRecFN(expWidth: Int, sigWidth: Int) extends Module
 {
     val io = IO(new Bundle {
-        val a = Output(Bits((expWidth + sigWidth).W))
+        val a = Input(Bits((expWidth + sigWidth).W))
         val out = Output(Bits((expWidth + sigWidth).W))
         val check = Output(Bool())
         val pass = Output(Bool())


### PR DESCRIPTION
Since chisel newbies are not familiar with Chisel2 now, old style will introduce burdens to maintaining in community.
This PR removes legacy `import Chisel._` usage and give new tester2 based strategy. And also remove `Driver` which should be deprecated soon.

- [x] sbt and mill sub-project support.
- [x] In suite test passed.
- [] test with rocket-chip.
- [x] LEC with legacy flow.