### PR TITLE
wake build system support

### DIFF
--- a/here.wake
+++ b/here.wake
@@ -1,0 +1,5 @@
+# This .wake file is used by the 'wake' build system.
+# Using this hardfloatRoot definition, other components can find where
+# the the hardfloat repository is located within a wake workspace.
+# 'here' resolves to the directory that this file resides.
+global def hardfloatRoot = here


### PR DESCRIPTION
This adds support to let the [wake](https://github.com/sifive/wake/) build system find where you have placed your checkout of hardfloat.
The current strategy for wake builds when finding repositories that it depends on, is to use hard-coded relative paths ([example from rocket-chip](https://github.com/chipsalliance/rocket-chip/blob/master/build.wake#L7)), this PR would loosen that constraint for hardfloat.