### PR TITLE
Revert bump.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ version := "1.3-SNAPSHOT"
 
 name := "hardfloat"
 
-scalaVersion := "2.12.12"
+scalaVersion := "2.12.8"
 
 scalacOptions += "-Xsource:2.11"
 
@@ -13,7 +13,7 @@ resolvers ++= Seq(
   Resolver.sonatypeRepo("releases")
 )
 
-val defaultVersions = Map("chisel3" -> "3.4-SNAPSHOT")
+val defaultVersions = Map("chisel3" -> "3.3-SNAPSHOT")
 
 // Provide a managed dependency on chisel if -DchiselVersion="" issupplied on the command line.
 libraryDependencies ++= (Seq("chisel3").map {

--- a/build.sc
+++ b/build.sc
@@ -7,7 +7,7 @@ import coursier.maven.MavenRepository
 // Please retain it.
 // Provide a managed dependency on X if -DXVersion="" is supplied on the command line.
 val defaultVersions = Map(
-  "chisel3" -> "3.4-SNAPSHOT",
+  "chisel3" -> "3.3-SNAPSHOT",
 )
 
 def getVersion(dep: String, org: String = "edu.berkeley.cs") = {
@@ -17,7 +17,7 @@ def getVersion(dep: String, org: String = "edu.berkeley.cs") = {
 object hardfloat extends hardfloat 
 
 class hardfloat extends ScalaModule with SbtModule with PublishModule { m =>
-  def scalaVersion = "2.12.12"
+  def scalaVersion = "2.12.8"
   // different scala version shares same sources
   // mill use foo/2.11.12 foo/2.12.11 as millSourcePath by default
   override def millSourcePath = super.millSourcePath / os.up

--- a/src/test/scala/FMATester.scala
+++ b/src/test/scala/FMATester.scala
@@ -7,7 +7,6 @@ import chisel3.stage.ChiselGeneratorAnnotation
 import firrtl.AnnotationSeq
 import firrtl.options.TargetDirAnnotation
 import firrtl.stage.OutputFileAnnotation
-import firrtl.util.BackendCompilationUtilities._
 import scala.sys.process.{Process, ProcessLogger}
 
 trait FMATester extends HardfloatTester {

--- a/src/test/scala/HardfloatTester.scala
+++ b/src/test/scala/HardfloatTester.scala
@@ -1,5 +1,9 @@
 package hardfloat.test
 
+import java.io.File
+import java.nio.file.Files
+import java.text.SimpleDateFormat
+import java.util.Calendar
 import logger.LazyLogging
 import org.scalatest.ParallelTestExecution
 import org.scalatest.flatspec.AnyFlatSpec
@@ -26,4 +30,19 @@ trait HardfloatTester extends AnyFlatSpec with Matchers with ParallelTestExecuti
     "-rnear_maxMag" -> "4",
     "-rodd" -> "6"
   )
+
+  lazy val TestDirectory = new File("test_run_dir")
+
+  def timeStamp: String = {
+    val format = new SimpleDateFormat("yyyyMMddHHmmss")
+    val now = Calendar.getInstance.getTime
+    format.format(now)
+  }
+
+  def createTestDirectory(testName: String): File = {
+    val outer = new File(TestDirectory, testName)
+    outer.mkdirs()
+    Files.createTempDirectory(outer.toPath, timeStamp).toFile
+  }
+
 }

--- a/src/test/scala/ValExec_CompareRecFN.scala
+++ b/src/test/scala/ValExec_CompareRecFN.scala
@@ -164,7 +164,7 @@ class CompareRecFNSpec extends FMATester {
         check(test(32, "le"))
     }
     "CompareRecF64_le" should "pass" in {
-        check(test(64, "lt"))
+        check(test(64, "le"))
     }
     "CompareRecF16_eq" should "pass" in {
         check(test(16, "eq"))


### PR DESCRIPTION
This PR contains two commits, 

157025e was my fault, previous version didn't run test CompareRec64_le

09e419d revert scala back to 2.12.8 and chisel to 3.3. We can bump this back after chipsalliance/rocket-chip#2617 merged.