### PR TITLE
Make DivSqrtRecFN_small tolerant to X-pessimism

### DIFF
--- a/src/main/scala/DivSqrtRecFN_small.scala
+++ b/src/main/scala/DivSqrtRecFN_small.scala
@@ -322,8 +322,6 @@ class
         isInf_Z    := isInf_S
         isZero_Z   := isZero_S
         sign_Z     := sign_S
-    }
-    when (entering_normalCase) {
         sExp_Z :=
             Mux(io.sqrtOp,
                 (rawA_S.sExp>>1) +& (BigInt(1)<<(expWidth - 1)).S,
@@ -356,10 +354,10 @@ class
     val trialRem = rem.zext - trialTerm.zext
     val newBit = (0.S <= trialRem)
 
-    when (entering_normalCase || !(idle || cycleNum(2))) {
+    when (entering || !(idle || cycleNum(2))) {
         rem_Z := Mux(newBit, trialRem.asUInt, rem)
     }
-    when (entering_normalCase || (! inReady && newBit)) {
+    when (entering || (! inReady && newBit)) {
         notZeroRem_Z := (trialRem =/= 0.S)
         sigX_Z :=
             Mux(inReady && ! io.sqrtOp, newBit<<(sigWidth + 1),  0.U) |


### PR DESCRIPTION
In the recoded format, many bits are don't-cares for Inf, NaN, and zero.
Alas, taking advantage of that relies on sane processing of don't-cares,
which Verilog X does not have.

Luckily, in this case, the fix actually slightly reduces HW cost.