### PR TITLE
feat: fix scala 2.13 removing Par

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,6 +14,7 @@ resolvers ++= Seq(
 addCompilerPlugin("edu.berkeley.cs" % "chisel3-plugin" % "3.5.4" cross CrossVersion.full)
 libraryDependencies += "edu.berkeley.cs" %% "chisel3" % "3.5.4"
 libraryDependencies ++= Seq("org.scalatest" %% "scalatest" % "3.2.0" % "test")
+libraryDependencies += "org.scala-lang.modules" %% "scala-parallel-collections" % "1.0.4"
 Test / testForkedParallel := true
 
 publishMavenStyle := true

--- a/build.sc
+++ b/build.sc
@@ -8,6 +8,7 @@ object v {
   val chisel3 = ivy"edu.berkeley.cs::chisel3:3.5.4"
   val chisel3Plugin = ivy"edu.berkeley.cs:::chisel3-plugin:3.5.4"
   val scalatest = ivy"org.scalatest::scalatest:3.2.0"
+  val scalapar = ivy"org.scala-lang.modules::scala-parallel-collections:1.0.4"
 }
 
 object hardfloat extends hardfloat
@@ -50,7 +51,7 @@ class hardfloat extends ScalaModule with SbtModule with PublishModule { m =>
   )
 
   object test extends Tests {
-    def ivyDeps = Agg(v.scalatest)
+    def ivyDeps = Agg(v.scalatest, v.scalapar)
     def testFramework = "org.scalatest.tools.Framework"
   }
 

--- a/src/test/scala/FMATester.scala
+++ b/src/test/scala/FMATester.scala
@@ -8,6 +8,8 @@ import firrtl.AnnotationSeq
 import firrtl.options.TargetDirAnnotation
 import firrtl.stage.OutputFileAnnotation
 import scala.sys.process.{Process, ProcessLogger}
+import scala.collection.parallel.CollectionConverters._
+
 
 trait FMATester extends HardfloatTester {
   def check(stdouts: Seq[String]) = {


### PR DESCRIPTION
Scala 2.13 removed parallal collections from standard library in 2.13. This commit adds the new repo as a separate dependency to fix that sbt test can run successfully

Signed-off-by: Tianrui Wei <tianrui@tianruiwei.com>