### PR TITLE
Update resizeRawFloat.scala

### DIFF
--- a/hardfloat/src/main/scala/resizeRawFloat.scala
+++ b/hardfloat/src/main/scala/resizeRawFloat.scala
@@ -69,7 +69,7 @@ object resizeRawFloat
             (if (in.sigWidth <= sigWidth)
                  in.sig<<(sigWidth - in.sigWidth)
              else
-                 in.sig(in.sigWidth + 2, in.sigWidth - sigWidth + 1) ##
+                 in.sig(in.sigWidth, in.sigWidth - sigWidth + 1) ##
                      in.sig(in.sigWidth - sigWidth, 0).orR
                  )
         out


### PR DESCRIPTION
This code would actually have caused a "high index XX is out of range" error in Chisel 5