### PR TITLE
Releasing reset in RecFNToIN.cpp wrapper

### DIFF
--- a/hardfloat/tests/resources/csrc/RecFNToIN.cpp
+++ b/hardfloat/tests/resources/csrc/RecFNToIN.cpp
@@ -50,6 +50,7 @@ int main (int argc, char* argv[])
         module.clock = 1;
         module.eval();
     }
+    module.reset = 0;
 
     // main operation
     for (;;) {


### PR DESCRIPTION
Found by @yildizr

I believe this has no impact in the current hardfloat implementation has the module under test `RecFNToIn` looks to be combinational, so reset has no effect (https://github.com/ucb-bar/berkeley-hardfloat/blob/26f00d00c3f3f57480065e02bfcfde3d3b41ec51/hardfloat/src/main/scala/RecFNToIN.scala#L46) but this looks like something we may want to clean-up (in case people want to implement a multi-cycle / pipelined version).