### PR TITLE
fix: bump sbt version to be same as rest of chipyard

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.8
+sbt.version=1.8.2


### PR DESCRIPTION
title; QC/QA: `sbt test` passes

fixes:
```
java.lang.UnsupportedOperationException: The Security Manager is deprecated and will be removed in a future release
        at java.base/java.lang.System.setSecurityManager(System.java:429)
        at sbt.TrapExit$.installManager(TrapExit.scala:53)
        at sbt.StandardMain$.runManaged(Main.scala:127)
        at sbt.xMain$.run(Main.scala:67)
        at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
        at java.base/java.lang.reflect.Method.invoke(Method.java:578)
        at sbt.internal.XMainConfiguration.run(XMainConfiguration.scala:45)
        at sbt.xMain.run(Main.scala:39)
        at xsbt.boot.Launch$.run$$anonfun$1(Launch.scala:132)
        at xsbt.boot.Launch$.withContextLoader(Launch.scala:157)
        at xsbt.boot.Launch$.run(Launch.scala:132)
        at xsbt.boot.Launch$.apply$$anonfun$1(Launch.scala:43)
        at xsbt.boot.Launch$.launch(Launch.scala:142)
        at xsbt.boot.Launch$.apply(Launch.scala:43)
        at xsbt.boot.Launch$.apply(Launch.scala:24)
        at xsbt.boot.Boot$.runImpl(Boot.scala:73)
        at xsbt.boot.Boot$.run(Boot.scala:69)
        at xsbt.boot.Boot$.main(Boot.scala:23)
        at xsbt.boot.Boot.main(Boot.scala)
[error] [launcher] error during sbt launcher: java.lang.UnsupportedOperationException: The Security Manager is deprecated and will be removed in a future release
```